### PR TITLE
Add custom 404 page

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Страница не найдена</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/src/components/NotFound.js
+++ b/src/components/NotFound.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const NotFound = () => (
+  <div className="min-h-screen flex flex-col items-center justify-center bg-anix-dark text-center p-4">
+    <h1 className="text-7xl font-heading font-bold text-anix-teal mb-6">404</h1>
+    <p className="text-2xl text-white mb-8">Страница не найдена</p>
+    <a href="/" className="px-6 py-3 bg-anix-purple hover:bg-anix-teal transition-colors rounded-md text-white">Вернуться на главную</a>
+  </div>
+);
+
+export default NotFound;

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,14 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './App.css';
 import App from './App';
+import NotFound from './components/NotFound';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(<App />);
+const base = process.env.PUBLIC_URL || '';
+const relativePath = window.location.pathname.replace(base, '') || '/';
+
+if (relativePath === '/' || relativePath === '/index.html') {
+  root.render(<App />);
+} else {
+  root.render(<NotFound />);
+}


### PR DESCRIPTION
## Summary
- create a `NotFound` component for the 404 page
- render it for unknown paths in `index.js`
- add a `public/404.html` for GitHub Pages

## Testing
- `npm test --silent --no-watch` *(fails: No tests found and npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686fbc6c490c8320881a50a172edeb51