### PR TITLE
Fix hero title width

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -137,7 +137,9 @@ body {
   position: relative;
   z-index: 3;
   text-align: center;
-  max-width: 800px;
+  max-width: 1200px;
+  margin: 0 auto;
+  width: 100%;
   padding: 0 24px;
 }
 


### PR DESCRIPTION
## Summary
- expand hero title container to full width

## Testing
- `CI=true npm test --silent -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_687091dda5dc8320ae7c46e0c777b2f9