### PR TITLE
Fix timeline text alignment

### DIFF
--- a/src/components/AnixLandingPage.js
+++ b/src/components/AnixLandingPage.js
@@ -270,7 +270,7 @@ const TimelineStep = ({ step, index, isActive, setActiveStep, isLast }) => {
               {step.subtitle}
             </p>
 
-            <p className="text-lg text-white/80 leading-relaxed max-w-md w-full ${!isEven ? '' 'mr-[200px]' : 'mr-[100px]'} ">
+            <p className="text-lg text-white/80 leading-relaxed max-w-md w-full">
               {step.description}
             </p>
           </div>


### PR DESCRIPTION
## Summary
- correct paragraph styles so timeline descriptions align with their headings

## Testing
- `CI=true npm test --silent -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_687094465fc88320909f1b9cce5107a8