### PR TITLE
Fix hero layout and add basic layout tests

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -137,9 +137,7 @@ body {
   position: relative;
   z-index: 3;
   text-align: center;
-  max-width: 1200px;
-  margin: 0 auto;
-  width: 100%;
+  max-width: 800px;
   padding: 0 24px;
 }
 
@@ -148,8 +146,7 @@ body {
   margin-bottom: 32px;
   animation: fadeInUp 1s ease-out 0.1s forwards;
   opacity: 0;
-  transform: translateY(30px);
-  transform: scale(1.5); /* Увеличивает весь контейнер в 1.5 раза */
+  transform: translateY(30px) scale(1.5); /* Увеличивает весь контейнер в 1.5 раза */
   transform-origin: top center; /* Точка трансформации (верхний центр) */
 }
 

--- a/src/__tests__/layout.test.js
+++ b/src/__tests__/layout.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-dom/test-utils';
+import fs from 'fs';
+import App from '../App';
+
+test('hero section appears after loading and has three lines', () => {
+  jest.useFakeTimers();
+  // Polyfill IntersectionObserver for JSDOM
+  global.IntersectionObserver = class {
+    constructor() {}
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  TestUtils.act(() => {
+    ReactDOM.render(<App />, container);
+  });
+
+  expect(container.querySelector('.loading-screen')).toBeTruthy();
+
+  TestUtils.act(() => {
+    jest.runAllTimers();
+  });
+
+  const heroTitle = container.querySelector('.hero-title');
+  expect(heroTitle).toBeTruthy();
+  expect(heroTitle.querySelectorAll('.title-line').length).toBe(3);
+});
+
+test('hero-content has expected max width', () => {
+  const css = fs.readFileSync('src/App.css', 'utf8');
+  const match = css.match(/\.hero-content\s*\{[^}]*\}/);
+  expect(match).not.toBeNull();
+  expect(match[0]).toMatch(/max-width:\s*800px/);
+});

--- a/src/components/AnixLandingPage.js
+++ b/src/components/AnixLandingPage.js
@@ -1,12 +1,12 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { motion, useInView, useScroll, useTransform } from 'framer-motion';
 import { Play, Zap, BarChart3, Palette, Brain } from 'lucide-react';
-import one from '/home/runner/work/anix_landing/anix_landing/src/images/1.png';
-import two from '/home/runner/work/anix_landing/anix_landing/src/images/2.png';
-import three from '/home/runner/work/anix_landing/anix_landing/src/images/3.png';
-import four from '/home/runner/work/anix_landing/anix_landing/src/images/4.png';
-import five from '/home/runner/work/anix_landing/anix_landing/src/images/5.png';
-import six from '/home/runner/work/anix_landing/anix_landing/src/images/6.png';
+import one from '../images/1.png';
+import two from '../images/2.png';
+import three from '../images/3.png';
+import four from '../images/4.png';
+import five from '../images/5.png';
+import six from '../images/6.png';
 
 const AnixLandingPage = () => {
   const containerRef = useRef(null);

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,2 @@
+// test setup file - left intentionally blank
+


### PR DESCRIPTION
## Summary
- revert hero container width to 800px
- fix logo translate/scale combination
- fix image import paths
- add minimal Jest tests to render the page and check layout basics

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68709a05b50c83209b479230b7c5526c