### PR TITLE
Fix overlay text on small screens

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2192,6 +2192,11 @@ body {
   .package-card {
     padding: 20px;
   }
+
+  .expertise-badge {
+    font-size: 12px;
+    padding: 8px 12px;
+  }
   
   .contact-method {
     padding: 16px;


### PR DESCRIPTION
## Summary
- tweak expertise badge font size for mobile screens

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6870ba4c2bd083209a5b0de665686d9d