### PR TITLE
Fix mobile slider alignment

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2082,7 +2082,7 @@ body {
   .awards-scroll .award-card {
     flex: 0 0 80%;
     min-width: 80%;
-    scroll-snap-align: center;
+    scroll-snap-align: start;
   }
 
   .team-grid,
@@ -2094,13 +2094,14 @@ body {
     scroll-snap-type: x mandatory;
     -webkit-overflow-scrolling: touch;
     touch-action: pan-y;
+    justify-content: flex-start;
   }
 
   .team-card,
   .testimonial-card {
     flex: 0 0 80%;
     min-width: 80%;
-    scroll-snap-align: center;
+    scroll-snap-align: start;
   }
   
   .process-section-v2 {


### PR DESCRIPTION
## Summary
- improve mobile slider behavior so first slide aligns flush left
- align awards and testimonial slides to start

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6870cc8413e48320a46911960133b725