### PR TITLE
Enable swipe without external dependency

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1455,6 +1455,7 @@ body {
   display: flex;
   gap: 32px;
   overflow-x: auto;
+  white-space: nowrap;
   scroll-behavior: smooth;
   padding: 20px 0;
   scrollbar-width: none;
@@ -2077,6 +2078,7 @@ body {
   .awards-scroll {
     scroll-snap-type: x mandatory;
     touch-action: pan-y;
+    white-space: nowrap;
   }
 
   .awards-scroll .award-card {
@@ -2090,6 +2092,7 @@ body {
     display: flex;
     flex-wrap: nowrap;
     overflow-x: auto;
+    white-space: nowrap;
     gap: 16px;
     scroll-snap-type: x mandatory;
     -webkit-overflow-scrolling: touch;

--- a/src/App.js
+++ b/src/App.js
@@ -32,6 +32,18 @@ const AnixAILanding = () => {
   const processRef = useRef(null);
   const particlesRef = useRef(null);
   const awardsScrollRef = useRef(null);
+  const touchStartX = useRef(0);
+
+  const handleTouchStart = (e) => {
+    touchStartX.current = e.touches[0].clientX;
+  };
+
+  const handleTouchEnd = (e) => {
+    const deltaX = e.changedTouches[0].clientX - touchStartX.current;
+    if (Math.abs(deltaX) > 50) {
+      scrollAwards(deltaX > 0 ? 'left' : 'right');
+    }
+  };
 
   // Animated counter effect
   useEffect(() => {
@@ -680,7 +692,12 @@ const AnixAILanding = () => {
               ◀
             </button>
             
-            <div className="awards-scroll" ref={awardsScrollRef}>
+            <div
+              className="awards-scroll"
+              ref={awardsScrollRef}
+              onTouchStart={handleTouchStart}
+              onTouchEnd={handleTouchEnd}
+            >
               {awards.map((award, index) => (
                 <div key={index} className="award-card">
                   <div className="award-trophy">


### PR DESCRIPTION
## Summary
- drop `react-swipeable` dependency
- implement touch-based swipe support in the awards slider
- keep nowrap slider styles for mobile
- clean up tests

## Testing
- `npm test --silent -- -u --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6870e13bcaa883208056d180e7435f18