### PR TITLE
Fix awards swipe without react-swipeable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "autoprefixer": "^10.4.17",
         "framer-motion": "^11.0.0",
         "lucide-react": "^0.365.0",
-        "react-swipeable": "^7.1.0",
         "postcss": "^8.4.30",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "autoprefixer": "^10.4.17",
     "framer-motion": "^11.0.0",
     "lucide-react": "^0.365.0",
-    "react-swipeable": "^7.1.0",
     "postcss": "^8.4.30",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { useSwipeable } from 'react-swipeable';
 import './App.css';
 import AnixLandingPage from "./components/AnixLandingPage";
 import god from './images/god.jpg';
@@ -33,11 +32,27 @@ const AnixAILanding = () => {
   const processRef = useRef(null);
   const particlesRef = useRef(null);
   const awardsScrollRef = useRef(null);
-  const swipeHandlers = useSwipeable({
-    onSwipedLeft: () => scrollAwards('right'),
-    onSwipedRight: () => scrollAwards('left'),
-    trackMouse: true
-  });
+  const swipeStart = useRef(0);
+
+  const handleTouchStart = (e) => {
+    swipeStart.current = e.touches[0].clientX;
+  };
+
+  const handleTouchEnd = (e) => {
+    const deltaX = e.changedTouches[0].clientX - swipeStart.current;
+    if (deltaX > 50) scrollAwards('left');
+    if (deltaX < -50) scrollAwards('right');
+  };
+
+  const handleMouseDown = (e) => {
+    swipeStart.current = e.clientX;
+  };
+
+  const handleMouseUp = (e) => {
+    const deltaX = e.clientX - swipeStart.current;
+    if (deltaX > 50) scrollAwards('left');
+    if (deltaX < -50) scrollAwards('right');
+  };
 
   // Animated counter effect
   useEffect(() => {
@@ -686,7 +701,14 @@ const AnixAILanding = () => {
               ◀
             </button>
             
-            <div className="awards-scroll" ref={awardsScrollRef} {...swipeHandlers}>
+            <div
+              className="awards-scroll"
+              ref={awardsScrollRef}
+              onTouchStart={handleTouchStart}
+              onTouchEnd={handleTouchEnd}
+              onMouseDown={handleMouseDown}
+              onMouseUp={handleMouseUp}
+            >
               {awards.map((award, index) => (
                 <div key={index} className="award-card">
                   <div className="award-trophy">


### PR DESCRIPTION
## Summary
- remove `react-swipeable` dependency since CI can't find the package
- implement simple pointer/touch handlers for award card scrolling

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6870e462b0e88320acf4b3848c0f45cf