### PR TITLE
Fix award card width on mobile

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2077,8 +2077,8 @@ body {
   }
 
   .awards-scroll .award-card {
-    flex: 0 0 80%;
-    min-width: 80%;
+    flex: 0 0 60%;
+    min-width: 60%;
     scroll-snap-align: start;
   }
 
@@ -2232,7 +2232,7 @@ body {
   }
   
   .award-card {
-    min-width: 80%;
+    min-width: 60%;
     padding: 24px 16px;
   }
   


### PR DESCRIPTION
## Summary
- reduce award card width on screens up to 768px
- narrow award cards further on small screens

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6870ea91295883208e8e8dfb0a261f5c