### PR TITLE
Implement pricing carousel

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1172,10 +1172,45 @@ body {
   background: #1a1a1a;
 }
 
-.pricing-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
-  gap: 40px;
+.pricing-carousel-container {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+}
+
+.pricing-nav {
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  background: linear-gradient(45deg, #8b45ff, #20b2aa);
+  border: none;
+  color: white;
+  font-size: 18px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  flex-shrink: 0;
+  z-index: 2;
+}
+
+.pricing-nav:hover {
+  transform: scale(1.1);
+  box-shadow: 0 8px 24px rgba(139, 69, 255, 0.4);
+}
+
+.pricing-carousel {
+  display: flex;
+  gap: 32px;
+  overflow-x: auto;
+  white-space: nowrap;
+  scroll-behavior: smooth;
+  padding: 20px 0;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.pricing-carousel::-webkit-scrollbar {
+  display: none;
 }
 
 .pricing-column {
@@ -1185,6 +1220,8 @@ body {
   border-radius: 24px;
   padding: 32px;
   transition: transform 0.3s ease;
+  flex: 0 0 350px;
+  min-width: 350px;
 }
 
 .pricing-column:hover {
@@ -2063,9 +2100,16 @@ body {
   .team-grid,
   .testimonials-grid,
   .blog-grid,
-  .pricing-grid {
-    grid-template-columns: 1fr;
-    gap: 24px;
+  .pricing-carousel {
+    scroll-snap-type: x mandatory;
+    touch-action: pan-x;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .pricing-column {
+    flex: 0 0 80%;
+    min-width: 80%;
+    scroll-snap-align: start;
   }
 
   /* Mobile sliders */
@@ -2180,6 +2224,10 @@ body {
   .scroll-button {
     display: none;
   }
+
+  .pricing-nav {
+    display: none;
+  }
   
   .floating-telegram {
     bottom: 20px;
@@ -2235,6 +2283,11 @@ body {
     min-width: 60%;
     padding: 24px 16px;
   }
+
+  .pricing-column {
+    flex: 0 0 90%;
+    min-width: 90%;
+  }
   
   .ai-brain {
     width: 120px;
@@ -2243,6 +2296,10 @@ body {
   
   .step-info-panel {
     padding: 20px;
+  }
+
+  .pricing-nav {
+    display: none;
   }
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -32,7 +32,9 @@ const AnixAILanding = () => {
   const processRef = useRef(null);
   const particlesRef = useRef(null);
   const awardsScrollRef = useRef(null);
+  const pricingScrollRef = useRef(null);
   const swipeStart = useRef(0);
+  const pricingSwipeStart = useRef(0);
 
   const handleTouchStart = (e) => {
     swipeStart.current = e.touches[0].clientX;
@@ -52,6 +54,26 @@ const AnixAILanding = () => {
     const deltaX = e.clientX - swipeStart.current;
     if (deltaX > 50) scrollAwards('left');
     if (deltaX < -50) scrollAwards('right');
+  };
+
+  const handlePricingTouchStart = (e) => {
+    pricingSwipeStart.current = e.touches[0].clientX;
+  };
+
+  const handlePricingTouchEnd = (e) => {
+    const deltaX = e.changedTouches[0].clientX - pricingSwipeStart.current;
+    if (deltaX > 50) scrollPricing('left');
+    if (deltaX < -50) scrollPricing('right');
+  };
+
+  const handlePricingMouseDown = (e) => {
+    pricingSwipeStart.current = e.clientX;
+  };
+
+  const handlePricingMouseUp = (e) => {
+    const deltaX = e.clientX - pricingSwipeStart.current;
+    if (deltaX > 50) scrollPricing('left');
+    if (deltaX < -50) scrollPricing('right');
   };
 
   // Animated counter effect
@@ -451,6 +473,16 @@ const AnixAILanding = () => {
     }
   };
 
+  const scrollPricing = (direction) => {
+    if (pricingScrollRef.current) {
+      const scrollAmount = 400;
+      pricingScrollRef.current.scrollBy({
+        left: direction === 'left' ? -scrollAmount : scrollAmount,
+        behavior: 'smooth'
+      });
+    }
+  };
+
   useEffect(() => {
     setTimeout(() => setIsLoading(false), 1500);
   }, []);
@@ -609,10 +641,22 @@ const AnixAILanding = () => {
       <section className="pricing-section">
         <div className="container">
           <h2 className="section-title">Цены и Пакеты</h2>
-          
-          <div className="pricing-grid">
-            {Object.entries(pricingPackages).map(([category, packages]) => (
-              <div key={category} className="pricing-column">
+
+          <div className="pricing-carousel-container">
+            <button className="pricing-nav left" onClick={() => scrollPricing('left')}>
+              ◀
+            </button>
+
+            <div
+              className="pricing-carousel"
+              ref={pricingScrollRef}
+              onTouchStart={handlePricingTouchStart}
+              onTouchEnd={handlePricingTouchEnd}
+              onMouseDown={handlePricingMouseDown}
+              onMouseUp={handlePricingMouseUp}
+            >
+              {Object.entries(pricingPackages).map(([category, packages]) => (
+                <div key={category} className="pricing-column">
                 <div className="column-header">
                   <h3>{category}</h3>
                   <div className="column-subtitle">
@@ -621,7 +665,7 @@ const AnixAILanding = () => {
                     {category === 'Корпорации' && 'Решения корпоративного уровня'}
                   </div>
                 </div>
-                
+
                 <div className="packages-list">
                   {packages.map((pkg, index) => (
                     <div key={index} className="package-card">
@@ -654,7 +698,12 @@ const AnixAILanding = () => {
                   ))}
                 </div>
               </div>
-            ))}
+              ))}
+            </div>
+
+            <button className="pricing-nav right" onClick={() => scrollPricing('right')}>
+              ▶
+            </button>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- convert pricing section to a horizontal carousel
- add navigation buttons and swipe handling
- style carousel and update responsive rules

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6870fbe247848320816c303bb1a00a5b