### PR TITLE
Fix mobile interactions and add width test

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -392,6 +392,10 @@ body {
   opacity: 1;
 }
 
+.service-overlay.show {
+  opacity: 1;
+}
+
 .case-study {
   text-align: center;
   color: white;
@@ -1502,6 +1506,8 @@ body {
 
 .award-card {
   min-width: 240px;
+  max-width: 320px;
+  overflow-wrap: anywhere;
   background: rgba(255, 255, 255, 0.05);
   backdrop-filter: blur(20px);
   border: 1px solid rgba(255, 255, 255, 0.1);
@@ -2102,7 +2108,6 @@ body {
   .blog-grid,
   .pricing-carousel {
     scroll-snap-type: x mandatory;
-    touch-action: pan-x;
     -webkit-overflow-scrolling: touch;
   }
 
@@ -2115,7 +2120,6 @@ body {
   /* Mobile sliders */
   .awards-scroll {
     scroll-snap-type: x mandatory;
-    touch-action: pan-x;
     -webkit-overflow-scrolling: touch;
     white-space: nowrap;
   }
@@ -2123,6 +2127,7 @@ body {
   .awards-scroll .award-card {
     flex: 0 0 60%;
     min-width: 60%;
+    max-width: 320px;
     scroll-snap-align: start;
   }
 
@@ -2135,7 +2140,6 @@ body {
     gap: 16px;
     scroll-snap-type: x mandatory;
     -webkit-overflow-scrolling: touch;
-    touch-action: pan-x;
     justify-content: flex-start;
   }
 
@@ -2225,9 +2229,6 @@ body {
     display: none;
   }
 
-  .pricing-nav {
-    display: none;
-  }
   
   .floating-telegram {
     bottom: 20px;
@@ -2281,6 +2282,7 @@ body {
   
   .award-card {
     min-width: 60%;
+    max-width: 320px;
     padding: 24px 16px;
   }
 
@@ -2298,9 +2300,6 @@ body {
     padding: 20px;
   }
 
-  .pricing-nav {
-    display: none;
-  }
 }
 
 /* Cyberpunk Effects */
@@ -2398,5 +2397,11 @@ body {
 ::selection{background:rgba(110,15,216,.3);color:#fff;}
 ::-moz-selection{background:rgba(110,15,216,.3);color:#fff;}
 button:focus,a:focus{outline:2px solid #6E0FD8;outline-offset:2px;}
+
+@media (min-width: 769px) {
+  .pricing-nav {
+    display: none;
+  }
+}
 
 

--- a/src/App.js
+++ b/src/App.js
@@ -35,6 +35,7 @@ const AnixAILanding = () => {
   const pricingScrollRef = useRef(null);
   const swipeStart = useRef(0);
   const pricingSwipeStart = useRef(0);
+  const [activeService, setActiveService] = useState(null);
 
   const handleTouchStart = (e) => {
     swipeStart.current = e.touches[0].clientX;
@@ -465,21 +466,47 @@ const AnixAILanding = () => {
 
   const scrollAwards = (direction) => {
     if (awardsScrollRef.current) {
-      const scrollAmount = 300;
-      awardsScrollRef.current.scrollBy({
-        left: direction === 'left' ? -scrollAmount : scrollAmount,
-        behavior: 'smooth'
-      });
+      const container = awardsScrollRef.current;
+      const card = container.querySelector('.award-card');
+      const cardWidth = card ? card.offsetWidth + 32 : 300;
+      const maxScroll = container.scrollWidth - container.clientWidth;
+
+      if (direction === 'left') {
+        if (container.scrollLeft <= 0) {
+          container.scrollTo({ left: maxScroll, behavior: 'smooth' });
+        } else {
+          container.scrollBy({ left: -cardWidth, behavior: 'smooth' });
+        }
+      } else {
+        if (container.scrollLeft >= maxScroll) {
+          container.scrollTo({ left: 0, behavior: 'smooth' });
+        } else {
+          container.scrollBy({ left: cardWidth, behavior: 'smooth' });
+        }
+      }
     }
   };
 
   const scrollPricing = (direction) => {
     if (pricingScrollRef.current) {
-      const scrollAmount = 400;
-      pricingScrollRef.current.scrollBy({
-        left: direction === 'left' ? -scrollAmount : scrollAmount,
-        behavior: 'smooth'
-      });
+      const container = pricingScrollRef.current;
+      const card = container.querySelector('.pricing-column');
+      const cardWidth = card ? card.offsetWidth + 32 : 400;
+      const maxScroll = container.scrollWidth - container.clientWidth;
+
+      if (direction === 'left') {
+        if (container.scrollLeft <= 0) {
+          container.scrollTo({ left: maxScroll, behavior: 'smooth' });
+        } else {
+          container.scrollBy({ left: -cardWidth, behavior: 'smooth' });
+        }
+      } else {
+        if (container.scrollLeft >= maxScroll) {
+          container.scrollTo({ left: 0, behavior: 'smooth' });
+        } else {
+          container.scrollBy({ left: cardWidth, behavior: 'smooth' });
+        }
+      }
     }
   };
 
@@ -545,12 +572,15 @@ const AnixAILanding = () => {
         <div className="container">
           <h2 className="section-title">Видео, которое помогает продавать</h2>
           <div className="services-grid">
-            <div className="service-card">
+            <div
+              className="service-card"
+              onClick={() => setActiveService(activeService === 0 ? null : 0)}
+            >
               <div className="service-icon">🎬</div>
               <h3>Сокращение цикла сделки</h3>
               <p>Меньше времени уходит на прогрев, презентации и убеждение.</p>
               <p>"Мы теряем клиентов из-за долгих обсуждений и недопонимания".</p>
-              <div className="service-overlay">
+              <div className={`service-overlay ${activeService === 0 ? 'show' : ''}`}>
                 <div className="case-study">
                   <h4>Превентивная победа</h4>
                   <p>Наши клиенты в среднем сократили цикл сделки в 3 раза.</p>
@@ -562,12 +592,15 @@ const AnixAILanding = () => {
               </div>
             </div>
             
-            <div className="service-card">
+            <div
+              className="service-card"
+              onClick={() => setActiveService(activeService === 1 ? null : 1)}
+            >
               <div className="service-icon">⚡</div>
               <h3>Масштабирование</h3>
               <p>Видео легко тиражируется, работает на новых рынках, языках, партнёрах.</p>
               <p>"Хочу выйти в США, но нужен контент под локаль".</p>
-              <div className="service-overlay">
+              <div className={`service-overlay ${activeService === 1 ? 'show' : ''}`}>
                 <div className="case-study">
                   <h4>История успеха</h4>
                   <p>Обычно наш клиент увеличивает конверсию в отклик от 10 раз.</p>
@@ -579,12 +612,15 @@ const AnixAILanding = () => {
               </div>
             </div>
             
-            <div className="service-card">
+            <div
+              className="service-card"
+              onClick={() => setActiveService(activeService === 2 ? null : 2)}
+            >
               <div className="service-icon">🎨</div>
               <h3>Конкурентная Упаковка</h3>
               <p>Продукт визуально и эмоционально выигрывает у конкурентов.</p>
               <p>"На фоне других выглядим скучно, нас не запоминают".</p>
-              <div className="service-overlay">
+              <div className={`service-overlay ${activeService === 2 ? 'show' : ''}`}>
                 <div className="case-study">
                   <h4>Вау эффект</h4>
                   <p>Выделитесь на конференции и лендинге</p>

--- a/src/__tests__/layout.test.js
+++ b/src/__tests__/layout.test.js
@@ -40,3 +40,10 @@ test('hero-content has expected max width', () => {
   expect(match).not.toBeNull();
   expect(match[0]).toMatch(/max-width:\s*800px/);
 });
+
+test('award card fits mobile width', () => {
+  const css = fs.readFileSync('src/App.css', 'utf8');
+  const match = css.match(/\.award-card\s*\{[^}]*\}/);
+  expect(match).not.toBeNull();
+  expect(match[0]).toMatch(/max-width:\s*320px/);
+});


### PR DESCRIPTION
## Summary
- prevent touch overlay on scroll by toggling services with click only
- allow vertical scrolling in carousels
- hide pricing navigation on desktop
- cap award card width and add unit test
- cyclic scrolling for awards and pricing carousels

## Testing
- `CI=1 npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68710b44c5b883208ad0f271ebf7383b