### PR TITLE
Fix award cards for mobile

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2135,7 +2135,7 @@ body {
   .awards-scroll .award-card {
     flex: 0 0 60%;
     min-width: 60%;
-    max-width: 320px;
+    max-width: 300px;
     scroll-snap-align: start;
   }
 
@@ -2294,7 +2294,7 @@ body {
   
   .award-card {
     min-width: 60%;
-    max-width: 320px;
+    max-width: 300px;
     padding: 24px 16px;
   }
 


### PR DESCRIPTION
## Summary
- set mobile width of awards cards to 300px max

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68714b8e1e88832081e9f5b21fc7a38d