### PR TITLE
Improve mobile pricing and awards behavior

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1172,7 +1172,7 @@ body {
 
 /* Pricing Section */
 .pricing-section {
-  padding: 120px 0 60px;
+  padding: 80px 0 60px;
   background: #1a1a1a;
 }
 
@@ -2281,6 +2281,7 @@ body {
   .blog-card,
   .package-card {
     padding: 20px;
+    text-align: center;
   }
 
   .expertise-badge {
@@ -2293,9 +2294,15 @@ body {
   }
   
   .award-card {
-    min-width: 60%;
-    max-width: 300px;
+    min-width: 55%;
+    max-width: 240px;
     padding: 24px 16px;
+  }
+
+  .package-header {
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
   }
 
   .pricing-column {

--- a/src/App.js
+++ b/src/App.js
@@ -468,7 +468,10 @@ const AnixAILanding = () => {
     if (awardsScrollRef.current) {
       const container = awardsScrollRef.current;
       const card = container.querySelector('.award-card');
-      const cardWidth = card ? card.offsetWidth + 32 : 300;
+      const cardWidth =
+        window.innerWidth <= 768
+          ? container.clientWidth
+          : (card ? card.offsetWidth + 32 : 300);
       const maxScroll = container.scrollWidth - container.clientWidth;
 
       if (direction === 'left') {
@@ -491,7 +494,10 @@ const AnixAILanding = () => {
     if (pricingScrollRef.current) {
       const container = pricingScrollRef.current;
       const card = container.querySelector('.pricing-column');
-      const cardWidth = card ? card.offsetWidth + 32 : 400;
+      const cardWidth =
+        window.innerWidth <= 768
+          ? container.clientWidth
+          : (card ? card.offsetWidth + 32 : 400);
       const maxScroll = container.scrollWidth - container.clientWidth;
 
       if (direction === 'left') {

--- a/src/components/AnixLandingPage.js
+++ b/src/components/AnixLandingPage.js
@@ -159,7 +159,7 @@ const AnixLandingPage = () => {
       >
 
         {/* Our Process Timeline */}
-        <section ref={timelineRef} className="py-20 px-4">
+        <section ref={timelineRef} className="pt-20 pb-10 px-4">
           <div className="max-w-7xl mx-auto">
             <motion.div
               className="text-center mb-20"


### PR DESCRIPTION
## Summary
- reduce gap before pricing section
- center pricing cards on small screens and show price on a new line
- limit award card size on phones
- adjust swipe logic so cards scroll one screen
- shrink Roadmap section bottom padding

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68715043d60483208b89a86ba1971c9f