### PR TITLE
Center awards carousel cards

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1505,6 +1505,9 @@ body {
   padding: 20px 0;
   scrollbar-width: none;
   -ms-overflow-style: none;
+  scroll-snap-type: x mandatory;
+  scroll-padding-left: 50%;
+  scroll-padding-right: 50%;
 }
 
 .awards-scroll::-webkit-scrollbar {
@@ -1512,8 +1515,10 @@ body {
 }
 
 .award-card {
+  flex: 0 0 auto;
+  width: 100%;
+  max-width: 300px;
   min-width: 240px;
-  max-width: 320px;
   overflow-wrap: anywhere;
   background: rgba(255, 255, 255, 0.05);
   backdrop-filter: blur(20px);
@@ -1524,6 +1529,7 @@ body {
   transition: all 0.4s ease;
   position: relative;
   overflow: hidden;
+  scroll-snap-align: center;
 }
 
 .award-card:hover {
@@ -2133,15 +2139,17 @@ body {
   /* Mobile sliders */
   .awards-scroll {
     scroll-snap-type: x mandatory;
+    scroll-padding-left: 50%;
+    scroll-padding-right: 50%;
     -webkit-overflow-scrolling: touch;
     white-space: nowrap;
   }
 
   .awards-scroll .award-card {
-    flex: 0 0 60%;
-    min-width: 60%;
+    flex: 0 0 auto;
+    width: 100%;
     max-width: 300px;
-    scroll-snap-align: start;
+    scroll-snap-align: center;
   }
 
   .team-grid,
@@ -2302,9 +2310,10 @@ body {
   }
   
   .award-card {
-    min-width: 55%;
-    max-width: 240px;
+    width: 100%;
+    max-width: 300px;
     padding: 24px 16px;
+    scroll-snap-align: center;
   }
 
   .package-header {

--- a/src/__tests__/layout.test.js
+++ b/src/__tests__/layout.test.js
@@ -45,5 +45,5 @@ test('award card fits mobile width', () => {
   const css = fs.readFileSync('src/App.css', 'utf8');
   const match = css.match(/\.award-card\s*\{[^}]*\}/);
   expect(match).not.toBeNull();
-  expect(match[0]).toMatch(/max-width:\s*320px/);
+  expect(match[0]).toMatch(/max-width:\s*300px/);
 });


### PR DESCRIPTION
## Summary
- center award cards in the recognition carousel
- limit card width to 300px
- adjust tests for new width

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687158e051008320ac5f00cec92f2983