### PR TITLE
Update favicon and testimonial preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,14 +11,14 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta property="og:title" content="Anix — видео, которое продаёт">
   <meta property="og:description" content="Видео, которое объясняет ваш продукт лучше любого сейлза. Продающий ролик за 10 дней.">
-  <meta property="og:image" content="https://anix.video/preview.jpg">
+  <meta property="og:image" content="3.png">
   <meta property="og:url" content="https://anix.video/">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Anix — explainer видео для роста продаж">
   <meta name="twitter:description" content="Создаем видео, которые понятны даже закупщику. Рост CTR, LTV, уменьшение CAC.">
-  <meta name="twitter:image" content="https://anix.video/preview.jpg">
-  <link rel="icon" href="favicon.png">
+  <meta name="twitter:image" content="3.png">
+  <link rel="icon" href="anix_wand.png">
   <link rel="manifest" href="manifest.json">
   <script type="application/ld+json">
     {

--- a/public/3.png
+++ b/public/3.png
@@ -1,0 +1,1 @@
+../src/images/3.png

--- a/public/anix_wand.png
+++ b/public/anix_wand.png
@@ -1,0 +1,1 @@
+../src/images/anix_wand.png

--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,7 @@
     <!-- Open Graph -->
     <meta property="og:title" content="Anix — видео, которое продаёт" />
     <meta property="og:description" content="Видео, которое объясняет ваш продукт лучше любого сейлза. Продающий ролик за 10 дней." />
-    <meta property="og:image" content="https://anix.video/preview.jpg" />
+    <meta property="og:image" content="%PUBLIC_URL%/3.png" />
     <meta property="og:url" content="https://anix.video/" />
     <meta property="og:type" content="website" />
 
@@ -21,9 +21,9 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Anix — explainer видео для роста продаж" />
     <meta name="twitter:description" content="Создаем видео, которые понятны даже закупщику. Рост CTR, LTV, уменьшение CAC." />
-    <meta name="twitter:image" content="https://anix.video/preview.jpg" />
+    <meta name="twitter:image" content="%PUBLIC_URL%/3.png" />
 
-    <link rel="icon" href="%PUBLIC_URL%/favicon.png" />
+    <link rel="icon" href="%PUBLIC_URL%/anix_wand.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
 
     <script type="application/ld+json">

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "description": "Explainer-видео для бизнеса",
   "icons": [
     {
-      "src": "logo.png",
+      "src": "anix_wand.png",
       "sizes": "192x192",
       "type": "image/png"
     }

--- a/src/App.js
+++ b/src/App.js
@@ -391,7 +391,7 @@ const AnixAILanding = () => {
       name: 'Фонд Целевого Капитала МФТИ',
       company: 'Физтех',
       text: 'Работать с командой Anix было очень приятно — ребята с самого начала погрузились в задачу, предлагали яркие визуальные концепты и всегда были на связи. Я особенно оценила их внимательность к деталям и умение слышать: когда мы в процессе работы поняли, что нам важно добавить наш ключевой слоган «Исследовать дальше!» — они очень органично встроили его в финал, чтобы он действительно звучал и запоминался.\n\nМне было важно, чтобы ролик не был дежурным — а передавал дух ФЦК и был интересен выпускникам. Ребята с этим справились — предлагали варианты, были открыты к обсуждению, исправляли моменты по тексту (например, фразы вроде «лучшие из лучших», которые нам показались неудачными), и в целом двигались гибко и без лишней формальности.\n\nСпасибо большое всей команде — за профессионализм, энергичность и лёгкость в общении. Получилось живо, современно и по делу. Надеюсь, это не последний наш совместный проект!',
-      videoThumbnail: fiztech,
+      videoThumbnail: 'https://vumbnail.com/1102413873.jpg',
       videoUrl: 'https://player.vimeo.com/video/1102413873?badge=0&autopause=0&player_id=0&app_id=58479',
       reach: 100,
       conversion: 10
@@ -663,7 +663,11 @@ const AnixAILanding = () => {
         <div className="container">
           <h2 className="section-title">Истории Успеха Клиентов</h2>
           <div className="testimonials-grid">
-            {testimonials.map((testimonial) => (
+            {testimonials.map((testimonial) => {
+              const previewText = testimonial.text.length > 350
+                ? `${testimonial.text.slice(0, 350)}...`
+                : testimonial.text;
+              return (
               <div key={testimonial.id} className="testimonial-card">
                 <div className="video-preview" onClick={() => {
                   setSelectedVideo(testimonial);
@@ -681,14 +685,14 @@ const AnixAILanding = () => {
                   </div>
                 </div>
                 <div className="testimonial-content">
-                  <p>"{testimonial.text}"</p>
+                  <p>"{previewText}"</p>
                   <div className="testimonial-author">
                     <strong>{testimonial.name}</strong>
                     <span>{testimonial.company}</span>
                   </div>
                 </div>
               </div>
-            ))}
+            )})}
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- link favicon and preview images from existing files
- update manifest icon
- change FЦК case thumbnail to video preview
- show only the first 350 characters of testimonial text on the page

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6879ec3b29f883208c39e1016400d453