### PR TITLE
Add linting and formatting setup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,27 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "jest": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:jsx-a11y/recommended",
+    "prettier"
+  ],
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true
+    }
+  },
+  "plugins": ["react", "jsx-a11y"],
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },
+  "rules": {}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+build/
+.DS_Store
+.env
+coverage/

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if [ -z "$husky_skip_init" ]; then
+  debug () {
+    [ "$HUSKY_DEBUG" = "1" ] && echo "husky: $*"
+  }
+  readonly hook_name="$(basename "$0")"
+  debug "starting $hook_name..."
+  readonly husky_dir="$(dirname "$(dirname "$0")")"
+  readonly git_params="$*"
+  if [ -f "$husky_dir/.huskyrc" ]; then
+    debug "reading $husky_dir/.huskyrc"
+    . "$husky_dir/.huskyrc"
+  fi
+  export readonly husky_skip_init=1
+  sh -e "$husky_dir/.husky/$hook_name" "$git_params"
+  exitCode="$?"
+  debug "$hook_name finished with exit code $exitCode"
+  exit "$exitCode"
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,22 @@
+{
+  "extends": ["stylelint-config-standard", "stylelint-config-tailwindcss"],
+  "plugins": ["stylelint-prettier"],
+  "rules": {
+    "declaration-property-unit-disallowed-list": {
+      "width": ["px"],
+      "min-width": ["px"],
+      "max-width": ["px"]
+    },
+    "declaration-property-value-disallowed-list": {
+      "min-width": [">100vw"],
+      "overflow-x": ["auto", "scroll"],
+      "position": ["absolute", "fixed"],
+      "*": ["vw", "vh"]
+    },
+    "declaration-block-no-duplicate-properties": true,
+    "prettier/prettier": true,
+    "declaration-property-value-required-list": {
+      "box-sizing": ["border-box"]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,18 @@
     "tailwindcss": "^3.4.0"
   },
   "devDependencies": {
-    "gh-pages": "^6.3.0"
+    "gh-pages": "^6.3.0",
+    "eslint": "^8.57.1",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-jsx-a11y": "^6.7.1",
+    "eslint-config-prettier": "^9.1.0",
+    "prettier": "^3.0.0",
+    "husky": "^9.0.0",
+    "lint-staged": "^15.2.0",
+    "stylelint": "^16.2.1",
+    "stylelint-config-standard": "^36.0.0",
+    "stylelint-config-tailwindcss": "^0.0.7",
+    "stylelint-prettier": "^2.0.0"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -22,7 +33,11 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d build"
+    "deploy": "gh-pages -d build",
+    "lint": "eslint src",
+    "format": "prettier --write \"src/**/*.{js,jsx,css}\"",
+    "lint:css": "stylelint \"src/**/*.{css,scss}\"",
+    "prepare": "husky install"
   },
   "browserslist": {
     "production": [
@@ -34,6 +49,17 @@
       "last 1 chrome version",
       "last 1 firefox version",
       "last 1 safari version"
+    ]
+  },
+  "lint-staged": {
+    "src/**/*.{js,jsx,css}": [
+      "prettier --write",
+      "eslint --fix",
+      "git add"
+    ],
+    "src/**/*.{css,scss}": [
+      "stylelint --fix",
+      "git add"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- add ESLint + React + a11y rules
- add Prettier formatting config
- configure Stylelint with some mobile-focused rules
- create husky pre-commit hook and lint-staged
- ignore build and node_modules

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687de959e6a083209318ddcf9d7eabff