### PR TITLE
Adjust hero layout on mobile

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2233,6 +2233,11 @@ body {
   .anix-logo {
     width: 80px;
   }
+
+  /* Hide logo on mobile to keep hero title visible */
+  .logo-container {
+    display: none;
+  }
   
   .services-grid,
   .team-grid,


### PR DESCRIPTION
## Summary
- keep hero heading higher on mobile by hiding logo

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687defc0bd688320b27a7c62e139472e