### PR TITLE
Improve performance of landing

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
     }
   </script>
   <script defer="defer" src="/static/js/main.1679d6f0.js"></script>
+  <link rel="preload" href="/static/css/main.e3f0e811.css" as="style">
   <link href="/static/css/main.e3f0e811.css" rel="stylesheet">
 </head>
 <body>

--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,13 @@
 
     <link rel="icon" href="%PUBLIC_URL%/anix_wand.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <!-- preconnect for CDN used by lite-youtube-embed -->
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <link rel="preconnect" href="https://www.youtube.com" />
+    <link rel="preconnect" href="https://i.ytimg.com" />
+    <link rel="preconnect" href="https://player.vimeo.com" />
+    <link rel="preconnect" href="https://vumbnail.com" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/lite-youtube-embed@0.3.0/dist/lite-youtube-embed.css" />
 
     <script type="application/ld+json">
       {
@@ -40,8 +47,11 @@
         ]
       }
     </script>
+  </head>
+  <body>
+    <div id="root"></div>
     <!-- Yandex.Metrika counter with Content Analytics enabled -->
-    <script type="text/javascript">
+    <script>
       (function (m, e, t, r, i, k, a) {
         m[i] = m[i] || function () {
           (m[i].a = m[i].a || []).push(arguments);
@@ -66,17 +76,16 @@
         webvisor: true,
       });
     </script>
-    <noscript
-      ><div>
+    <noscript>
+      <div>
         <img
           src="https://mc.yandex.ru/watch/103290769"
           style="position:absolute; left:-9999px;"
           alt=""
-        /></div
-    ></noscript>
+        />
+      </div>
+    </noscript>
     <!-- /Yandex.Metrika counter -->
-  </head>
-  <body>
-    <div id="root"></div>
+    <script defer src="https://cdn.jsdelivr.net/npm/lite-youtube-embed@0.3.0/dist/lite-youtube-embed.js"></script>
   </body>
 </html>

--- a/src/App.js
+++ b/src/App.js
@@ -595,7 +595,13 @@ const AnixAILanding = () => {
         
         <div className="hero-content">
           <div className="logo-container">
-            <img src={logo} alt="анимационный ролик объясняющий B2B продукт" className="anix-logo" />
+            <img
+              src={logo}
+              alt="анимационный ролик объясняющий B2B продукт"
+              className="anix-logo"
+              loading="lazy"
+              decoding="async"
+            />
           </div>
           
           <h1 className="hero-title">
@@ -709,7 +715,12 @@ const AnixAILanding = () => {
                   setSelectedVideo(testimonial);
                   setShowVideoModal(true);
                 }}>
-                  <img src={testimonial.videoThumbnail} alt="анимационный ролик объясняющий B2B продукт" />
+                  <img
+                    src={testimonial.videoThumbnail}
+                    alt="анимационный ролик объясняющий B2B продукт"
+                    loading="lazy"
+                    decoding="async"
+                  />
                   <div className="video-play-button">
                     <div className="play-icon">▶</div>
                   </div>
@@ -751,7 +762,13 @@ const AnixAILanding = () => {
             {teamMembers.map((member, index) => (
               <div key={index} className="team-card">
                 <div className="team-image-container">
-                  <img src={member.image} alt="анимационный ролик объясняющий B2B продукт" className="team-image" />
+                  <img
+                    src={member.image}
+                    alt="анимационный ролик объясняющий B2B продукт"
+                    className="team-image"
+                    loading="lazy"
+                    decoding="async"
+                  />
                   <div className="team-overlay">
                     <div className="expertise-badges">
                       {member.tags.map((tag, i) => (
@@ -876,7 +893,12 @@ const AnixAILanding = () => {
               {awards.map((award, index) => (
                 <div key={index} className="award-card">
                   <div className="award-trophy">
-                    <img src={award.image} alt="анимационный ролик объясняющий B2B продукт" />
+                    <img
+                      src={award.image}
+                      alt="анимационный ролик объясняющий B2B продукт"
+                      loading="lazy"
+                      decoding="async"
+                    />
                     <div className="trophy-glow"></div>
                   </div>
                   <div className="award-info">
@@ -1060,15 +1082,11 @@ const AnixAILanding = () => {
         <div className="container">
           <h2 className="section-title">Интервью с основателями</h2>
           <div className="interview-video w-full max-w-4xl mx-auto">
-            {/* Responsive YouTube iframe */}
-            <iframe
-              className="w-full h-full"
-              src="https://www.youtube.com/embed/Tt5Bj1VHaqQ?si=RLY4WYH9sUZx_lUf"
-              title="Интервью с основателями"
-              frameBorder="0"
-              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-              allowFullScreen
-            ></iframe>
+            {/* Lightweight YouTube embed */}
+            <lite-youtube
+              videoid="Tt5Bj1VHaqQ"
+              style={{ width: '100%', height: '100%' }}
+            ></lite-youtube>
           </div>
         </div>
       </section>
@@ -1087,7 +1105,12 @@ const AnixAILanding = () => {
         
         {showQRCode && (
           <div className="qr-modal">
-            <img src={generateQRCode()} alt="анимационный ролик объясняющий B2B продукт" />
+            <img
+              src={generateQRCode()}
+              alt="анимационный ролик объясняющий B2B продукт"
+              loading="lazy"
+              decoding="async"
+            />
             <p>Сканируйте для связи</p>
           </div>
         )}
@@ -1108,6 +1131,7 @@ const AnixAILanding = () => {
                   allow="autoplay; fullscreen; picture-in-picture"
                   allowFullScreen
                   title={`Видео от ${selectedVideo.name}`}
+                  loading="lazy"
                 ></iframe>
                 <div className="progress-bar-container">
                   <div className="progress-label">Повышение охвата</div>


### PR DESCRIPTION
## Summary
- lazy load images and iframe
- use lite-youtube-embed for interview video
- preload CSS in index.html
- move and defer analytics script
- add preconnects for external resources

## Testing
- `node node_modules/eslint/bin/eslint.js src` *(fails: ESLint config not found)*
- `npm run lint:css` *(fails: stylelint not found)*
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687df1d027f88320afbf66d63d3c0bc8