### PR TITLE
Fix awards section UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,5 +54,19 @@
 </head>
 <body>
   <div id="root"></div>
+  <noscript>
+    <style>
+      .no-js-awards{padding:20px;display:flex;flex-direction:column;gap:16px;color:#fff;background:#1a1a1a;}
+      .no-js-awards h3{margin:0;font-size:18px;}
+      .no-js-awards span{font-size:14px;color:#ccc;}
+    </style>
+    <div class="no-js-awards">
+      <h3>ТОP-25 проектов акселератора 2024 <span>Инновации</span></h3>
+      <h3>Победители в номинации "Маркетинг" <span>Маркетинг</span></h3>
+      <h3>Победители "Меняющие реальность" <span>Социальное Воздействие</span></h3>
+      <h3>Победители второго потока <span>Акселератор</span></h3>
+      <h3>Победители <span>Общая категория</span></h3>
+    </div>
+  </noscript>
 </body>
 </html>

--- a/src/App.css
+++ b/src/App.css
@@ -1504,8 +1504,7 @@ body {
   position: relative;
   display: flex;
   align-items: center;
-  gap: 24px;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .scroll-button {
@@ -1520,20 +1519,30 @@ body {
   transition: all 0.3s ease;
   flex-shrink: 0;
   z-index: 2;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
 }
 
 .scroll-button:hover {
   transform: scale(1.1);
   box-shadow: 0 8px 24px rgba(139, 69, 255, 0.4);
 }
+.scroll-button.left {
+  left: 0;
+}
+.scroll-button.right {
+  right: 0;
+}
 
 .awards-scroll {
+    padding: 20px 16px;
   display: flex;
   gap: 32px;
   overflow-x: auto;
   white-space: nowrap;
   scroll-behavior: smooth;
-  padding: 20px 0;
+  padding: 20px 60px;
   scrollbar-width: none;
   -ms-overflow-style: none;
   scroll-snap-type: x mandatory;
@@ -1624,6 +1633,7 @@ body {
   margin-bottom: 8px;
   color: white;
   line-height: 1.3;
+  word-break: break-word;
 }
 
 .award-category {
@@ -2302,6 +2312,7 @@ body {
 
   /* Mobile sliders */
   .awards-scroll {
+    padding: 20px 16px;
     scroll-snap-type: x mandatory;
     scroll-padding-left: 50%;
     scroll-padding-right: 50%;

--- a/src/App.js
+++ b/src/App.js
@@ -878,7 +878,11 @@ const AnixAILanding = () => {
           <h2 className="section-title">Признание Индустрии</h2>
           
           <div className="awards-scroll-container">
-            <button className="scroll-button left" onClick={() => scrollAwards('left')}>
+            <button
+              className="scroll-button left"
+              aria-label="Предыдущая награда"
+              onClick={() => scrollAwards('left')}
+            >
               ◀
             </button>
             
@@ -891,7 +895,7 @@ const AnixAILanding = () => {
               onMouseUp={handleMouseUp}
             >
               {awards.map((award, index) => (
-                <div key={index} className="award-card">
+                <div key={index} className="award-card w-full max-w-xs flex-none">
                   <div className="award-trophy">
                     <img
                       src={award.image}
@@ -910,7 +914,11 @@ const AnixAILanding = () => {
               ))}
             </div>
             
-            <button className="scroll-button right" onClick={() => scrollAwards('right')}>
+            <button
+              className="scroll-button right"
+              aria-label="Следующая награда"
+              onClick={() => scrollAwards('right')}
+            >
               ▶
             </button>
           </div>


### PR DESCRIPTION
## Summary
- tweak awards carousel layout for better responsiveness
- prevent text clipping in awards cards
- add a basic noscript fallback list

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687df46d3b4483208991bb300d14f49c