### PR TITLE
Improve landing performance

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,8 @@
   </script>
   <script defer="defer" src="/static/js/main.1679d6f0.js"></script>
   <link rel="preload" href="/static/css/main.e3f0e811.css" as="style">
-  <link href="/static/css/main.e3f0e811.css" rel="stylesheet">
+  <link href="/static/css/main.e3f0e811.css" rel="stylesheet" media="print" onload="this.media='all'">
+  <noscript><link href="/static/css/main.e3f0e811.css" rel="stylesheet"></noscript>
 </head>
 <body>
   <div id="root"></div>

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,2 @@
+/static/*
+  Cache-Control: public, max-age=31536000

--- a/public/index.html
+++ b/public/index.html
@@ -31,6 +31,10 @@
     <link rel="preconnect" href="https://i.ytimg.com" />
     <link rel="preconnect" href="https://player.vimeo.com" />
     <link rel="preconnect" href="https://vumbnail.com" />
+    <!-- preconnect for analytics and fonts -->
+    <link rel="preconnect" href="https://mc.yandex.ru" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/lite-youtube-embed@0.3.0/dist/lite-youtube-embed.css" />
 
     <script type="application/ld+json">

--- a/src/App.js
+++ b/src/App.js
@@ -17,6 +17,10 @@ import dasha from './images/dasha.jpg';
 import TPES from './images/TPES.png';
 import BlogCard from './components/BlogCard';
 
+// Helper for responsive img attributes
+const makeSrcSet = (src) => `${src} 1x, ${src} 2x`;
+const responsiveSizes = '(max-width: 768px) 100vw, 600px';
+
 
 const AnixAILanding = () => {
   const [isLoading, setIsLoading] = useState(true);
@@ -512,54 +516,58 @@ const AnixAILanding = () => {
 
   const scrollAwards = (direction) => {
     if (awardsScrollRef.current) {
-      const container = awardsScrollRef.current;
-      const card = container.querySelector('.award-card');
-      const cardWidth =
-        window.innerWidth <= 768
-          ? container.clientWidth
-          : (card ? card.offsetWidth + 32 : 300);
-      const maxScroll = container.scrollWidth - container.clientWidth;
+      requestAnimationFrame(() => {
+        const container = awardsScrollRef.current;
+        const card = container.querySelector('.award-card');
+        const cardWidth =
+          window.innerWidth <= 768
+            ? container.clientWidth
+            : (card ? card.offsetWidth + 32 : 300);
+        const maxScroll = container.scrollWidth - container.clientWidth;
 
-      if (direction === 'left') {
-        if (container.scrollLeft <= 0) {
-          container.scrollTo({ left: maxScroll, behavior: 'smooth' });
+        if (direction === 'left') {
+          if (container.scrollLeft <= 0) {
+            container.scrollTo({ left: maxScroll, behavior: 'smooth' });
+          } else {
+            container.scrollBy({ left: -cardWidth, behavior: 'smooth' });
+          }
         } else {
-          container.scrollBy({ left: -cardWidth, behavior: 'smooth' });
+          if (container.scrollLeft >= maxScroll) {
+            container.scrollTo({ left: 0, behavior: 'smooth' });
+          } else {
+            container.scrollBy({ left: cardWidth, behavior: 'smooth' });
+          }
         }
-      } else {
-        if (container.scrollLeft >= maxScroll) {
-          container.scrollTo({ left: 0, behavior: 'smooth' });
-        } else {
-          container.scrollBy({ left: cardWidth, behavior: 'smooth' });
-        }
-      }
+      });
     }
   };
 
   const scrollPricing = (direction) => {
     if (pricingScrollRef.current) {
-      const container = pricingScrollRef.current;
-      const card = container.querySelector('.pricing-column');
-      const cardWidth =
-        window.innerWidth <= 768
-          ? container.clientWidth
-          : (card ? card.offsetWidth + 32 : 400);
-      const scrollAmount = cardWidth / 1.5;
-      const maxScroll = container.scrollWidth - container.clientWidth;
+      requestAnimationFrame(() => {
+        const container = pricingScrollRef.current;
+        const card = container.querySelector('.pricing-column');
+        const cardWidth =
+          window.innerWidth <= 768
+            ? container.clientWidth
+            : (card ? card.offsetWidth + 32 : 400);
+        const scrollAmount = cardWidth / 1.5;
+        const maxScroll = container.scrollWidth - container.clientWidth;
 
-      if (direction === 'left') {
-        if (container.scrollLeft <= 0) {
-          container.scrollTo({ left: maxScroll, behavior: 'smooth' });
+        if (direction === 'left') {
+          if (container.scrollLeft <= 0) {
+            container.scrollTo({ left: maxScroll, behavior: 'smooth' });
+          } else {
+            container.scrollBy({ left: -scrollAmount, behavior: 'smooth' });
+          }
         } else {
-          container.scrollBy({ left: -scrollAmount, behavior: 'smooth' });
+          if (container.scrollLeft >= maxScroll) {
+            container.scrollTo({ left: 0, behavior: 'smooth' });
+          } else {
+            container.scrollBy({ left: scrollAmount, behavior: 'smooth' });
+          }
         }
-      } else {
-        if (container.scrollLeft >= maxScroll) {
-          container.scrollTo({ left: 0, behavior: 'smooth' });
-        } else {
-          container.scrollBy({ left: scrollAmount, behavior: 'smooth' });
-        }
-      }
+      });
     }
   };
 
@@ -707,6 +715,8 @@ const AnixAILanding = () => {
                 }}>
                   <img
                     src={testimonial.videoThumbnail}
+                    srcSet={makeSrcSet(testimonial.videoThumbnail)}
+                    sizes={responsiveSizes}
                     alt="анимационный ролик объясняющий B2B продукт"
                     loading="lazy"
                     decoding="async"
@@ -754,6 +764,8 @@ const AnixAILanding = () => {
                 <div className="team-image-container">
                   <img
                     src={member.image}
+                    srcSet={makeSrcSet(member.image)}
+                    sizes={responsiveSizes}
                     alt="анимационный ролик объясняющий B2B продукт"
                     className="team-image"
                     loading="lazy"
@@ -889,6 +901,8 @@ const AnixAILanding = () => {
                   <div className="award-trophy">
                     <img
                       src={award.image}
+                      srcSet={makeSrcSet(award.image)}
+                      sizes={responsiveSizes}
                       alt="анимационный ролик объясняющий B2B продукт"
                       loading="lazy"
                       decoding="async"
@@ -1105,6 +1119,8 @@ const AnixAILanding = () => {
           <div className="qr-modal">
             <img
               src={generateQRCode()}
+              srcSet={`${generateQRCode()} 1x, ${generateQRCode()} 2x`}
+              sizes={responsiveSizes}
               alt="анимационный ролик объясняющий B2B продукт"
               loading="lazy"
               decoding="async"

--- a/src/components/AnixLandingPage.js
+++ b/src/components/AnixLandingPage.js
@@ -8,6 +8,10 @@ import four from '../images/4.png';
 import five from '../images/5.png';
 import six from '../images/6.png';
 
+// Helper for responsive images
+const makeSrcSet = (img) => `${img} 1x, ${img} 2x`;
+const responsiveSizes = '(max-width: 768px) 100vw, 600px';
+
 const AnixLandingPage = () => {
   const containerRef = useRef(null);
   const timelineRef = useRef(null);
@@ -338,6 +342,8 @@ const TimelineStep = ({ step, index, isActive, setActiveStep, isLast, isMobile }
               
               <img
                 src={step.image}
+                srcSet={makeSrcSet(step.image)}
+                sizes={responsiveSizes}
                 alt="анимационный ролик объясняющий B2B продукт"
                 className="relative z-10 w-full h-64 object-cover rounded-xl"
                 loading="lazy"


### PR DESCRIPTION
## Summary
- add responsive helpers and apply srcset/sizes to images
- use requestAnimationFrame in scroll functions
- preload fonts and analytics connections in HTML
- load CSS asynchronously
- cache static assets with `_headers`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687e0b159fe48320bfbfb9bcc92b927f