### PR TITLE
Update Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,9 +34,6 @@ jobs:
       - name: Prepare 404 page
         if: steps.npm-ci.outcome == 'success'
         run: cp build/index.html build/404.html
-        
-      - name: Add CNAME file
-        run: echo "studio.anix-ai.pro" > build/CNAME
 
       - name: Deploy to gh-pages
         if: steps.npm-ci.outcome == 'success'
@@ -45,3 +42,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build
           publish_branch: gh-pages
+          cname: studio.anix-ai.pro


### PR DESCRIPTION
## Summary
- update GitHub Pages workflow so the site automatically pushes to `gh-pages`
- use `peaceiris/actions-gh-pages@v4` with CNAME configuration

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687e1b5884e08320ba7c39e41925e864