### PR TITLE
Improve load performance via service worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,10 @@
   <meta name="twitter:image" content="3.png">
   <link rel="icon" href="anix_wand.png">
   <link rel="manifest" href="manifest.json">
+  <!-- Preconnect to external origins for faster first byte -->
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+  <link rel="preconnect" href="https://mc.yandex.ru">
+  <link rel="preconnect" href="https://mc.yandex.com">
   <!-- Yandex.Metrika counter with Content Analytics enabled -->
   <script type="text/javascript">
     (function(m,e,t,r,i,k,a){
@@ -69,5 +73,12 @@
       <h3>Победители <span>Общая категория</span></h3>
     </div>
   </noscript>
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('/service-worker.js');
+      });
+    }
+  </script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -27,6 +27,8 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <!-- preconnect for CDN used by lite-youtube-embed -->
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <link rel="preconnect" href="https://mc.yandex.ru" />
+    <link rel="preconnect" href="https://mc.yandex.com" />
     <link rel="preconnect" href="https://www.youtube.com" />
     <link rel="preconnect" href="https://i.ytimg.com" />
     <link rel="preconnect" href="https://player.vimeo.com" />
@@ -91,5 +93,12 @@
     </noscript>
     <!-- /Yandex.Metrika counter -->
     <script defer src="https://cdn.jsdelivr.net/npm/lite-youtube-embed@0.3.0/dist/lite-youtube-embed.js"></script>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('%PUBLIC_URL%/service-worker.js');
+        });
+      }
+    </script>
   </body>
 </html>

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,27 @@
+self.addEventListener('install', event => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open('anix-cache').then(cache =>
+      cache.match(event.request).then(response => {
+        const fetchPromise = fetch(event.request).then(networkResponse => {
+          if (networkResponse && networkResponse.status === 200) {
+            const contentType = networkResponse.headers.get('content-type') || '';
+            if (/javascript|css|image/.test(contentType)) {
+              cache.put(event.request, networkResponse.clone());
+            }
+          }
+          return networkResponse;
+        });
+        return response || fetchPromise;
+      })
+    )
+  );
+});

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,27 @@
+self.addEventListener('install', event => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open('anix-cache').then(cache =>
+      cache.match(event.request).then(response => {
+        const fetchPromise = fetch(event.request).then(networkResponse => {
+          if (networkResponse && networkResponse.status === 200) {
+            const contentType = networkResponse.headers.get('content-type') || '';
+            if (/javascript|css|image/.test(contentType)) {
+              cache.put(event.request, networkResponse.clone());
+            }
+          }
+          return networkResponse;
+        });
+        return response || fetchPromise;
+      })
+    )
+  );
+});


### PR DESCRIPTION
## Summary
- add preconnect hints
- register a service worker to cache JS/CSS/images

## Testing
- `npm test -- --watchAll=false`
- `node ./node_modules/eslint/bin/eslint.js src` *(fails: stylelint missing)*

------
https://chatgpt.com/codex/tasks/task_e_687e24d44fe083209bb54a2d0f0e66a0