### PR TITLE
Fix lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eject": "react-scripts eject",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
-    "lint": "eslint src",
+    "lint": "npx eslint src",
     "lint:fix": "eslint src --fix",
     "format": "prettier --write \"src/**/*.{js,jsx,css}\"",
     "lint:css": "stylelint \"src/**/*.{css,scss}\"",


### PR DESCRIPTION
## Summary
- run eslint through `npx` instead of directly

## Testing
- `npm run lint` *(fails: ESLint couldn't find eslint.config.*)*

------
https://chatgpt.com/codex/tasks/task_e_687e26dfa4488320bd28810532349212