### PR TITLE
feat: add supabase lead capture form

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "react-dom": "^18.2.0",
     "react-helmet": "^6.1.0",
     "react-scripts": "5.0.1",
-    "tailwindcss": "^3.4.0"
+    "tailwindcss": "^3.4.0",
+    "@supabase/supabase-js": "^2.42.0"
   },
   "devDependencies": {
     "gh-pages": "^6.3.0",
@@ -58,12 +59,10 @@
   "lint-staged": {
     "src/**/*.{js,jsx,css}": [
       "prettier --write",
-      "eslint --fix",
-      "git add"
+      "node node_modules/eslint/bin/eslint.js --fix"
     ],
     "src/**/*.{css,scss}": [
-      "stylelint --fix",
-      "git add"
+      "stylelint --fix"
     ]
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -793,7 +793,7 @@ const AnixAILanding = () => {
             Как explainer-видео повышает продажи сложных продуктов
           </h2>
           <p className="text-center text-white/70 mb-8">
-            Оставьте контакты и получите чек-лист
+            Получите бесплатный чек-лист для маркетинга сложных решений
           </p>
           <div className="max-w-md mx-auto">
             <LeadForm />
@@ -1082,8 +1082,7 @@ const AnixAILanding = () => {
         </div>
       </section>
 
-
-        {/* Subscribe Telegram Section */}
+      {/* Subscribe Telegram Section */}
       <section className="subscribe-section">
         <div className="container subscribe-container">
           <h3>Подпишись на наш телеграм канал</h3>

--- a/src/components/CookieBanner.js
+++ b/src/components/CookieBanner.js
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
 
 const CookieBanner = () => {
-  const [visible, setVisible] = useState(() => !localStorage.getItem('cookiesAccepted'));
+  const [visible, setVisible] = useState(
+    () => !localStorage.getItem('cookiesAccepted')
+  );
 
   const accept = () => {
     localStorage.setItem('cookiesAccepted', 'true');
@@ -12,7 +14,9 @@ const CookieBanner = () => {
 
   return (
     <div className="fixed bottom-0 left-0 right-0 bg-anix-dark text-white p-4 flex flex-col md:flex-row items-center justify-between z-50">
-      <p className="mb-2 md:mb-0">Мы используем cookie для улучшения сайта</p>
+      <p className="mb-2 md:mb-0">
+        Мы используем куки для аналитики и маркетинга.
+      </p>
       <button
         onClick={accept}
         className="bg-anix-purple hover:bg-anix-teal text-white px-4 py-2 rounded"
@@ -24,4 +28,3 @@ const CookieBanner = () => {
 };
 
 export default CookieBanner;
-

--- a/src/components/LeadForm.js
+++ b/src/components/LeadForm.js
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
+import { supabase } from '../supabaseClient';
 
 const LeadForm = ({ onSuccess }) => {
   const [formData, setFormData] = useState({
     email: '',
-    role: '',
+    position: '',
     telegram: '',
     consent: false,
   });
@@ -17,97 +18,104 @@ const LeadForm = ({ onSuccess }) => {
     }));
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    if (!formData.email || !formData.role || !formData.consent) return;
+    if (!formData.email || !formData.position || !formData.consent) return;
 
-    const data = { ...formData };
-    // Mock submission: replace with integration to Supabase, Notion API, etc.
-    console.log('Lead form submitted', data);
-    // Example placeholder: fetch('/api/lead', { method: 'POST', body: JSON.stringify(data) });
+    const { email, position, telegram } = formData;
+    const { error } = await supabase
+      .from('leads')
+      .insert([{ email, position, telegram }]);
 
-    setSubmitted(true);
-    onSuccess && onSuccess();
+    if (error) {
+      console.error(error);
+      alert('Ошибка. Попробуйте ещё раз.');
+    } else {
+      setSubmitted(true);
+      onSuccess && onSuccess();
+      alert('Спасибо! Чек-лист отправлен вам на почту.');
+    }
   };
 
   if (submitted) {
     return (
       <p className="text-center text-green-400">
-        Спасибо! Чек-лист отправлен вам на почту
+        Спасибо! Чек-лист отправлен вам на почту.
       </p>
     );
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <div>
-        <label className="block text-sm mb-1" htmlFor="email">
-          Email*
-        </label>
-        <input
-          id="email"
-          name="email"
-          type="email"
-          required
-          value={formData.email}
-          onChange={handleChange}
-          className="w-full px-3 py-2 rounded bg-anix-dark border border-gray-600 text-white"
-        />
-      </div>
-      <div>
-        <label className="block text-sm mb-1" htmlFor="role">
-          Должность*
-        </label>
-        <input
-          id="role"
-          name="role"
-          required
-          value={formData.role}
-          onChange={handleChange}
-          className="w-full px-3 py-2 rounded bg-anix-dark border border-gray-600 text-white"
-        />
-      </div>
-      <div>
-        <label className="block text-sm mb-1" htmlFor="telegram">
-          Telegram
-        </label>
-        <input
-          id="telegram"
-          name="telegram"
-          value={formData.telegram}
-          onChange={handleChange}
-          className="w-full px-3 py-2 rounded bg-anix-dark border border-gray-600 text-white"
-        />
-      </div>
-      <div className="flex items-center">
-        <input
-          id="consent"
-          name="consent"
-          type="checkbox"
-          required
-          checked={formData.consent}
-          onChange={handleChange}
-          className="mr-2"
-        />
-        <label htmlFor="consent" className="text-sm">
-          Я согласен(а) на обработку персональных данных
-        </label>
-      </div>
-      <button
-        type="submit"
-        className="w-full bg-anix-purple hover:bg-anix-teal text-white py-2 rounded transition-colors"
-      >
-        Получить чек-лист
-      </button>
+    <>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm mb-1" htmlFor="email">
+            Email*
+          </label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            required
+            value={formData.email}
+            onChange={handleChange}
+            className="w-full px-3 py-2 rounded bg-anix-dark border border-gray-600 text-white"
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1" htmlFor="position">
+            Должность*
+          </label>
+          <input
+            id="position"
+            name="position"
+            required
+            value={formData.position}
+            onChange={handleChange}
+            className="w-full px-3 py-2 rounded bg-anix-dark border border-gray-600 text-white"
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1" htmlFor="telegram">
+            Telegram
+          </label>
+          <input
+            id="telegram"
+            name="telegram"
+            value={formData.telegram}
+            onChange={handleChange}
+            className="w-full px-3 py-2 rounded bg-anix-dark border border-gray-600 text-white"
+          />
+        </div>
+        <div className="flex items-center">
+          <input
+            id="consent"
+            name="consent"
+            type="checkbox"
+            required
+            checked={formData.consent}
+            onChange={handleChange}
+            className="mr-2"
+          />
+          <label htmlFor="consent" className="text-sm">
+            Я согласен(а) на обработку персональных данных
+          </label>
+        </div>
+        <button
+          type="submit"
+          className="w-full bg-anix-purple hover:bg-anix-teal text-white py-2 rounded transition-colors"
+        >
+          Получить чек-лист
+        </button>
+      </form>
       <a
         href="#"
         className="block text-center text-xs text-gray-400 underline mt-2"
       >
-        Privacy Policy
+        Политика конфиденциальности
       </a>
-    </form>
+    </>
   );
 };
 
 export default LeadForm;
-

--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -1,0 +1,7 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = 'https://ppoygmaqlaiqcisjetea.supabase.co';
+const supabaseKey =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InBwb3lnbWFxbGFpcWNpc2pldGVhIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQ0MTMyNDUsImV4cCI6MjA2OTk4OTI0NX0.UU6BxEDmme9Tamsts4EVSNfBSublO7aqO8zYojrrHhI';
+
+export const supabase = createClient(supabaseUrl, supabaseKey);


### PR DESCRIPTION
## Summary
- integrate lead capture form with Supabase and privacy policy link
- add cookie consent banner text
- configure lint-staged for new ESLint invocation

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module '@supabase/supabase-js')*
- `npm run lint`
- `npm run lint:css` *(fails: prettier.resolveConfig.sync is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689240c235788320ac048ba81fa6d8c7