### PR TITLE
ci: adjust dev pages deployment

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Prepare 404 page
         run: cp build/index.html build/404.html
 
+      - name: Create CNAME for dev subdomain
+        run: echo dev.studio.anix-ai.pro > build/CNAME
+
       - name: Deploy to gh-pages dev folder
         uses: peaceiris/actions-gh-pages@v4
         with:
@@ -42,4 +45,4 @@ jobs:
           publish_dir: ./build
           publish_branch: gh-pages
           destination_dir: dev
-          cname: dev.studio.anix-ai.pro
+          keep_files: true


### PR DESCRIPTION
## Summary
- create CNAME and 404.html during dev build
- preserve existing gh-pages contents and remove root cname interaction

## Testing
- `npm test -- --watchAll=false`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6894b41a4c688320a9e4f3023ef67ed8