### PR TITLE
Add lead capture form and revise telegram CTA

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2074,25 +2074,34 @@ body {
   color: rgba(255, 255, 255, 0.6);
 }
 
-/* Subscribe & Brief Sections */
+/* Subscribe, Brief & Lead Form Sections */
 .subscribe-section,
-.brief-section {
+.brief-section,
+.lead-form-section {
   padding: 80px 0;
   background: #1a1a1a;
 }
 
 .subscribe-container {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   align-items: center;
   gap: 40px;
+  text-align: center;
 }
 
 .subscribe-section h3,
-.brief-section h3 {
+.brief-section h3,
+.lead-form-section h3 {
   font-size: 28px;
   font-weight: 600;
   color: #fff;
+  text-align: center;
+}
+
+.lead-form-container {
+  max-width: 600px;
+  margin: 0 auto;
 }
 
 .subscribe-btn {
@@ -2110,6 +2119,11 @@ body {
   align-items: center;
   justify-content: center;
   white-space: nowrap;
+  box-shadow: 0 0 25px rgba(139, 69, 255, 0.6);
+}
+
+.subscribe-btn:hover {
+  box-shadow: 0 0 35px rgba(139, 69, 255, 0.8);
 }
 
 .subscribe-btn .sparkles {
@@ -2455,7 +2469,8 @@ body {
   }
 
   .subscribe-section h3,
-  .brief-section h3 {
+  .brief-section h3,
+  .lead-form-section h3 {
     font-size: 20px;
   }
 

--- a/src/App.js
+++ b/src/App.js
@@ -17,6 +17,7 @@ import dasha from './images/dasha.jpg';
 import TPES from './images/TPES.png';
 import BlogCard from './components/BlogCard';
 import CookieBanner from './components/CookieBanner';
+import LeadForm from './components/LeadForm';
 
 // Helper for responsive img attributes
 const makeSrcSet = (src) => `${src} 1x, ${src} 2x`;
@@ -1041,6 +1042,14 @@ const AnixAILanding = () => {
         </div>
       </section>
 
+      {/* Lead Form Section */}
+      <section className="lead-form-section">
+        <div className="container lead-form-container">
+          <h3>Получите чек-лист по explainer-видео</h3>
+          <LeadForm />
+        </div>
+      </section>
+
       {/* Subscribe Telegram Section */}
       <section className="subscribe-section">
         <div className="container subscribe-container">
@@ -1393,11 +1402,7 @@ const AnixAILanding = () => {
         onClick={redirectToTelegram}
       >
         <div className="telegram-icon">✈</div>
-        <span>
-          {isMobile
-            ? 'Написать в Telegram'
-            : '📅 Забронировать слот → получить предложение за 24 часа'}
-        </span>
+        <span>🔮 Получить расчёт под мой проект</span>
         <div className="telegram-glow"></div>
 
         {showQRCode && (


### PR DESCRIPTION
## Summary
- embed lead capture form before Telegram subscribe block
- restyle Telegram subscribe section with centered glowing button
- update floating CTA text to "🔮 Получить расчёт под мой проект"

## Testing
- `npm test -- --watchAll=false`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6894d7fd24dc8320a7bc696160b89192