### PR TITLE
Improve mobile call-to-action layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -233,8 +233,11 @@ body {
 /* Buttons */
 .cta-button {
   position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   padding: 18px 36px;
-  font-size: 18px;
+  font-size: inherit;
   font-weight: 600;
   border: none;
   border-radius: 12px;
@@ -243,6 +246,8 @@ body {
   overflow: hidden;
   text-transform: uppercase;
   letter-spacing: 1px;
+  min-width: 44px;
+  min-height: 44px;
 }
 
 .cta-button.primary {
@@ -2443,6 +2448,12 @@ body {
   /* Hide logo on mobile to keep hero title visible */
   .logo-container {
     display: none;
+  }
+
+  .cta-button {
+    width: 100%;
+    padding: 16px 24px;
+    font-size: 16px;
   }
 
   .services-grid,

--- a/src/App.js
+++ b/src/App.js
@@ -742,7 +742,7 @@ const AnixAILanding = () => {
             href="https://t.me/m/i23MvBuLOGJi"
             target="_blank"
             rel="noopener noreferrer"
-            className="cta-button primary"
+            className="cta-button primary block w-full md:w-auto text-base md:text-lg"
             onMouseEnter={() => setIsPageBlurred(true)}
             onMouseLeave={() => setIsPageBlurred(false)}
           >
@@ -929,12 +929,12 @@ const AnixAILanding = () => {
         </div>
       </section>
 
-      <div className="container text-center mt-12">
+      <div className="container text-center my-12 md:my-16">
         <a
           href="https://t.me/m/i23MvBuLOGJi"
           target="_blank"
           rel="noopener noreferrer"
-          className="cta-button primary"
+          className="cta-button primary block w-full md:w-auto text-base md:text-lg"
           onMouseEnter={() => setIsPageBlurred(true)}
           onMouseLeave={() => setIsPageBlurred(false)}
         >
@@ -946,12 +946,12 @@ const AnixAILanding = () => {
       {/*  👉 ставим Roadmap ЗА пределами .container */}
       <AnixLandingPage />
 
-      <div className="container text-center mt-12">
+      <div className="container text-center my-12 md:my-16">
         <a
           href="https://t.me/m/i23MvBuLOGJi"
           target="_blank"
           rel="noopener noreferrer"
-          className="cta-button primary"
+          className="cta-button primary block w-full md:w-auto text-base md:text-lg"
           onMouseEnter={() => setIsPageBlurred(true)}
           onMouseLeave={() => setIsPageBlurred(false)}
         >


### PR DESCRIPTION
## Summary
- make CTA buttons full width on mobile with adaptive text sizes
- add mobile-friendly spacing for standalone CTA sections
- enforce minimum touch target and responsive styles for buttons

## Testing
- `CI=true npm test --silent`
- `npm run lint --silent`
- `npx lint-staged` *(fails: TypeError: prettier.resolveConfig.sync is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6899dd0635048320a54a6e899193fe08