### PR TITLE
feat: temporarily hide brief section

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -35,7 +35,6 @@ const AnixAILanding = () => {
   const [processInView, setProcessInView] = useState(false);
   const [processStarted, setProcessStarted] = useState(false);
   const [isPageBlurred, setIsPageBlurred] = useState(false);
-
   const heroRef = useRef(null);
   const processRef = useRef(null);
   const particlesRef = useRef(null);
@@ -1246,7 +1245,8 @@ const AnixAILanding = () => {
         </div>
       </section>
 
-      {/* Brief Section */}
+      {/* Brief Section (temporarily hidden) */}
+      {/*
       <section className="brief-section">
         <div className="container subscribe-container">
           <h3>
@@ -1266,6 +1266,7 @@ const AnixAILanding = () => {
           </a>
         </div>
       </section>
+      */}
 
       {/* Contact Section */}
       <section className="contact-section">


### PR DESCRIPTION
## Summary
- hide the Telegram brief CTA section on the landing page

## Testing
- `npm run lint`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b34c8ce448320af94787471f90543