### PR TITLE
Improve section gradients and clean up layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1984,18 +1984,19 @@ body {
   overflow-x: auto;
 }
 
+
 .nda-table {
   width: 100%;
   max-width: 1000px;
   margin: 0 auto;
   border-collapse: collapse;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid #4b5563;
 }
 
 .nda-table th,
 .nda-table td {
   padding: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid #4b5563;
   text-align: left;
 }
 
@@ -2042,7 +2043,7 @@ body {
 
 .blog-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: 40px;
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -1301,7 +1301,7 @@ const AnixAILanding = () => {
           <h2 className="section-title">Свяжитесь с Нами</h2>
           <div className="contact-grid">
             <div className="contact-info">
-              <h3>Готовы революционизировать вашу анимацию?</h3>
+              <h3>Готовы прокачать вашу воронку продаж?</h3>
               <p>
                 Свяжитесь с нами любым удобным способом. Мы ответим в течение
                 часа!

--- a/src/AppLayout.tsx
+++ b/src/AppLayout.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef } from 'react';
-import StickyCTA from './components/StickyCTA';
 import { track } from './lib/analytics';
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
@@ -13,32 +12,14 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
       }
       lastSection.current = id;
     };
-    const onCTAview = () => track('cta_view', { section: lastSection.current });
-    const onCTAclick = () =>
-      track('cta_click', { section: lastSection.current });
-
     window.addEventListener('section-inview', onIn);
-    const obs = new MutationObserver(() => {
-      const el = document.querySelector('.cta-sticky');
-      if (el) {
-        onCTAview();
-      }
-    });
-    obs.observe(document.body, { childList: true, subtree: true });
-    window.addEventListener('cta-click', onCTAclick);
-
-    return () => {
-      window.removeEventListener('section-inview', onIn);
-      window.removeEventListener('cta-click', onCTAclick);
-      obs.disconnect();
-    };
+    return () => window.removeEventListener('section-inview', onIn);
   }, []);
 
   return (
     <>
       <div className="page-grain" aria-hidden />
       {children}
-      <StickyCTA />
     </>
   );
 }

--- a/src/styles/sections.css
+++ b/src/styles/sections.css
@@ -11,8 +11,11 @@ body { background: var(--bg-global); transition: background .4s ease; }
 /* 1) Градиент-мостик */
 .sep--gradient::before{
   content:""; position:absolute; inset:0;
-  background: linear-gradient(to bottom, var(--bg) 0%, var(--next-bg) 100%);
-  opacity:.95;
+  background:linear-gradient(
+    to bottom,
+    color-mix(in oklab, var(--bg) 20%, transparent) 0%,
+    color-mix(in oklab, var(--next-bg) 80%, transparent) 100%
+  );
 }
 
 /* 2) Кривая без SVG — через clip-path ellipse */
@@ -39,16 +42,4 @@ body { background: var(--bg-global); transition: background .4s ease; }
   mix-blend-mode:soft-light;
 }
 
-/* sticky CTA полоса */
-.cta-sticky{
-  position:sticky; bottom:12px; margin:0 auto; max-width:720px;
-  display:flex; gap:12px; align-items:center; justify-content:space-between;
-  padding:12px 14px; border-radius:14px;
-  background:
-    linear-gradient(90deg, color-mix(in oklab, var(--bg) 80%, white 20%), color-mix(in oklab, var(--next-bg) 80%, white 20%));
-  box-shadow:0 6px 24px rgba(0,0,0,.25);
-  z-index:5; backdrop-filter:blur(6px);
-}
-.cta-btn{ padding:10px 14px; border-radius:10px; font-weight:600; text-decoration:none;
-  background:linear-gradient(135deg, #6ae, #86f); color:#fff; }
-@media (min-width:768px){ .cta-sticky{ bottom:16px; } }
+/* sticky CTA полоса removed */


### PR DESCRIPTION
## Summary
- add color-mix gradient transitions between sections
- remove Telegram sticky CTA bar
- fix blog card grid overflow, update contact heading, and enhance NDA table borders

## Testing
- `npm run lint`
- `npm run lint:css` *(fails: prettier.resolveConfig.sync is not a function)*
- `npm test -- --watchAll=false` *(fails: Cannot find module 'https://deno.land/std@0.224.0/http/server.ts')*

------
https://chatgpt.com/codex/tasks/task_e_689b6932dfc883208c24e00292a0d119