### PR TITLE
chore: remove YouTube embeds

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,9 +21,8 @@
   <link rel="icon" href="anix_wand.png">
   <link rel="manifest" href="manifest.json">
   <!-- Preconnect to external origins for faster first byte -->
-  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
-  <link rel="preconnect" href="https://mc.yandex.ru">
-  <link rel="preconnect" href="https://mc.yandex.com">
+    <link rel="preconnect" href="https://mc.yandex.ru">
+    <link rel="preconnect" href="https://mc.yandex.com">
   <style>
     body{margin:0;font-family:'Inter',system-ui,sans-serif;background:#1a1a1a;color:#fff;line-height:1.6;overflow-x:hidden}
   </style>

--- a/public/index.html
+++ b/public/index.html
@@ -25,19 +25,14 @@
 
     <link rel="icon" href="%PUBLIC_URL%/anix_wand.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!-- preconnect for CDN used by lite-youtube-embed -->
-    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
     <link rel="preconnect" href="https://mc.yandex.ru" />
     <link rel="preconnect" href="https://mc.yandex.com" />
-    <link rel="preconnect" href="https://www.youtube.com" />
-    <link rel="preconnect" href="https://i.ytimg.com" />
     <link rel="preconnect" href="https://player.vimeo.com" />
     <link rel="preconnect" href="https://vumbnail.com" />
     <!-- preconnect for analytics and fonts -->
     <link rel="preconnect" href="https://mc.yandex.ru" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/lite-youtube-embed@0.3.0/dist/lite-youtube-embed.css" />
     <style>
       body{margin:0;font-family:'Inter',system-ui,sans-serif;background:#1a1a1a;color:#fff;line-height:1.6;overflow-x:hidden}
     </style>
@@ -95,7 +90,6 @@
       </div>
     </noscript>
     <!-- /Yandex.Metrika counter -->
-    <script defer src="https://cdn.jsdelivr.net/npm/lite-youtube-embed@0.3.0/dist/lite-youtube-embed.js"></script>
     <script>
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- drop YouTube preconnects and lite-youtube assets
- remove jsdelivr preconnect leftover

## Testing
- `CI=true npm test` *(fails: Cannot find module 'https://deno.land/std@0.224.0/http/server.ts')*
- `npm run lint`
- `npm run lint:css` *(fails: prettier.resolveConfig.sync is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689b80fa16d48320a9597d7e4180a5c2