### PR TITLE
feat: update supabase env names and cors

### DIFF
--- a/supabase/functions/email-open/index.ts
+++ b/supabase/functions/email-open/index.ts
@@ -1,19 +1,58 @@
-import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-const PNG_BASE64="iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAukB9oK9E2wAAAAASUVORK5CYII="; // 1x1 прозрачный png
-serve(async (req)=>{
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
+
+const ALLOW_ORIGIN = 'https://studio.anix-ai.pro';
+const cors = {
+  'Access-Control-Allow-Origin': ALLOW_ORIGIN,
+  'Access-Control-Allow-Headers': 'content-type',
+  'Access-Control-Allow-Methods': 'POST,OPTIONS,GET',
+};
+
+const PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAukB9oK9E2wAAAAASUVORK5CYII='; // 1x1 прозрачный png
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: cors });
+  }
+
+  const SB_URL = Deno.env.get('SB_URL');
+  const SB_SERVICE_ROLE_KEY = Deno.env.get('SB_SERVICE_ROLE_KEY');
+
+  if (!SB_URL || !SB_SERVICE_ROLE_KEY) {
+    return new Response(JSON.stringify({ error: 'misconfigured' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json', ...cors },
+    });
+  }
+
   const url = new URL(req.url);
   const lead_id = url.searchParams.get('lead_id') ?? undefined;
+
   try {
-    // лог в lead_events (не забывай createClient)
-    const { createClient } = await import("https://esm.sh/@supabase/supabase-js@2");
-    const sb = createClient(Deno.env.get("SUPABASE_URL")!, Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!);
+    const { createClient } = await import(
+      'https://esm.sh/@supabase/supabase-js@2'
+    );
+    const sb = createClient(SB_URL, SB_SERVICE_ROLE_KEY);
     await sb.from('lead_events').insert({
-      event_name:'email_open', lead_id, meta:{ t: Date.now() },
-      ip: req.headers.get('cf-connecting-ip') ?? req.headers.get('x-forwarded-for') ?? null,
-      ua: req.headers.get('user-agent') ?? null
+      event_name: 'email_open',
+      lead_id,
+      meta: { t: Date.now() },
+      ip:
+        req.headers.get('cf-connecting-ip') ??
+        req.headers.get('x-forwarded-for') ??
+        null,
+      ua: req.headers.get('user-agent') ?? null,
     });
   } catch {}
-  return new Response(Uint8Array.from(atob(PNG_BASE64), c=>c.charCodeAt(0)), {
-    headers:{ "Content-Type":"image/png", "Cache-Control":"no-store" }
-  });
+
+  return new Response(
+    Uint8Array.from(atob(PNG_BASE64), (c) => c.charCodeAt(0)),
+    {
+      headers: {
+        'Content-Type': 'image/png',
+        'Cache-Control': 'no-store',
+        ...cors,
+      },
+    }
+  );
 });

--- a/supabase/functions/submit-lead/index.ts
+++ b/supabase/functions/submit-lead/index.ts
@@ -1,6 +1,12 @@
-import { createClient } from '@supabase/supabase-js';
+const telegramRegex =
+  /^(@?[a-zA-Z0-9_]{5,32}|https?:\/\/t\.me\/[a-zA-Z0-9_]{5,32}|tg:\/\/resolve\?domain=[a-zA-Z0-9_]{5,32})$/;
 
-const telegramRegex = /^(@?[a-zA-Z0-9_]{5,32}|https?:\/\/t\.me\/[a-zA-Z0-9_]{5,32}|tg:\/\/resolve\?domain=[a-zA-Z0-9_]{5,32})$/;
+const ALLOW_ORIGIN = 'https://studio.anix-ai.pro';
+const cors = {
+  'Access-Control-Allow-Origin': ALLOW_ORIGIN,
+  'Access-Control-Allow-Headers': 'content-type',
+  'Access-Control-Allow-Methods': 'POST,OPTIONS,GET',
+};
 
 function buildTags(email: string, position: string): string[] {
   const tags: string[] = [];
@@ -11,7 +17,10 @@ function buildTags(email: string, position: string): string[] {
     { regex: /(edu|ac)/i, tag: 'education' },
     { regex: /(pharm|bio|med|clinic|dent)/i, tag: 'biotech_med' },
     { regex: /(ai|tech|dev|it|soft)/i, tag: 'it' },
-    { regex: /(realty|estate|devel|stroy|строй)/i, tag: 'real_estate_construction' },
+    {
+      regex: /(realty|estate|devel|stroy|строй)/i,
+      tag: 'real_estate_construction',
+    },
     { regex: /(gmail|yahoo|outlook|bk|mail\.ru|yandex)/i, tag: 'b2c' },
   ];
   for (const m of domainMap) {
@@ -33,54 +42,128 @@ function buildTags(email: string, position: string): string[] {
 }
 
 export default async function handler(req: Request): Promise<Response> {
-  try {
-    if (req.method !== 'POST') {
-      return new Response(JSON.stringify({ error: 'Method not allowed' }), { status: 405 });
-    }
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: cors });
+  }
 
-    const { email, position, telegram, consent, captchaToken, utm, referrer, pathname } = await req.json();
-
-    if (!email || !telegram || !telegramRegex.test(telegram) || consent !== true) {
-      return new Response(JSON.stringify({ error: 'Invalid input' }), { status: 400 });
-    }
-
-    const turnstileSecret = Deno.env.get('TURNSTILE_SECRET_KEY') || process.env.TURNSTILE_SECRET_KEY;
-    if (!turnstileSecret) {
-      return new Response(JSON.stringify({ error: 'Server misconfigured' }), { status: 500 });
-    }
-
-    const turnRes = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ secret: turnstileSecret, response: captchaToken }),
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { ...cors, 'Content-Type': 'application/json' },
     });
+  }
+
+  try {
+    const {
+      email,
+      position,
+      telegram,
+      consent,
+      captchaToken,
+      utm,
+      referrer,
+      pathname,
+    } = await req.json();
+
+    if (
+      !email ||
+      !telegram ||
+      !telegramRegex.test(telegram) ||
+      consent !== true
+    ) {
+      return new Response(JSON.stringify({ error: 'Invalid input' }), {
+        status: 400,
+        headers: { ...cors, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const turnstileSecret =
+      Deno.env.get('TURNSTILE_SECRET_KEY') || process.env.TURNSTILE_SECRET_KEY;
+    if (!turnstileSecret) {
+      return new Response(JSON.stringify({ error: 'misconfigured' }), {
+        status: 500,
+        headers: { ...cors, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const turnRes = await fetch(
+      'https://challenges.cloudflare.com/turnstile/v0/siteverify',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          secret: turnstileSecret,
+          response: captchaToken,
+        }),
+      }
+    );
     const turnJson = await turnRes.json();
     if (!turnJson.success) {
-      return new Response(JSON.stringify({ error: 'Captcha verification failed' }), { status: 400 });
+      return new Response(
+        JSON.stringify({ error: 'Captcha verification failed' }),
+        {
+          status: 400,
+          headers: { ...cors, 'Content-Type': 'application/json' },
+        }
+      );
     }
 
-    const supabaseUrl = Deno.env.get('SUPABASE_URL') || process.env.SUPABASE_URL;
-    const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') || process.env.SUPABASE_SERVICE_ROLE_KEY;
-    const supabase = createClient(supabaseUrl!, supabaseKey!);
+    const SB_URL = Deno.env.get('SB_URL') || process.env.SB_URL;
+    const SB_SERVICE_ROLE_KEY =
+      Deno.env.get('SB_SERVICE_ROLE_KEY') || process.env.SB_SERVICE_ROLE_KEY;
 
-    const ip = req.headers.get('x-forwarded-for') || req.headers.get('cf-connecting-ip') || '';
+    if (!SB_URL || !SB_SERVICE_ROLE_KEY) {
+      return new Response(JSON.stringify({ error: 'misconfigured' }), {
+        status: 500,
+        headers: { ...cors, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const { createClient } = await import(
+      'https://esm.sh/@supabase/supabase-js@2'
+    );
+    const sb = createClient(SB_URL, SB_SERVICE_ROLE_KEY);
+
+    const ip =
+      req.headers.get('x-forwarded-for') ||
+      req.headers.get('cf-connecting-ip') ||
+      '';
     const tags = buildTags(email, position || '');
-    const { data, error } = await supabase
+    const { data, error } = await sb
       .from('leads')
-      .insert({ email, position, telegram, consent, utm, referrer, pathname, ip, tags })
+      .insert({
+        email,
+        position,
+        telegram,
+        consent,
+        utm,
+        referrer,
+        pathname,
+        ip,
+        tags,
+      })
       .select()
       .single();
 
     if (error) {
-      return new Response(JSON.stringify({ error: 'Database error' }), { status: 500 });
+      return new Response(JSON.stringify({ error: 'Database error' }), {
+        status: 500,
+        headers: { ...cors, 'Content-Type': 'application/json' },
+      });
     }
 
     const leadId = data.id;
-    const resendKey = Deno.env.get('RESEND_API_KEY') || process.env.RESEND_API_KEY;
-    const supabaseUrlEnv = supabaseUrl;
+    const resendKey =
+      Deno.env.get('RESEND_API_KEY') || process.env.RESEND_API_KEY;
+    if (!resendKey) {
+      return new Response(JSON.stringify({ error: 'misconfigured' }), {
+        status: 500,
+        headers: { ...cors, 'Content-Type': 'application/json' },
+      });
+    }
     const htmlContent =
       `<p>Спасибо за интерес!</p>` +
-      `<img src="${supabaseUrlEnv}/functions/v1/email-open?lead_id=${leadId}&t=${Date.now()}" width="1" height="1" style="display:none" alt="">`;
+      `<img src="${SB_URL}/functions/v1/email-open?lead_id=${leadId}&t=${Date.now()}" width="1" height="1" style="display:none" alt="">`;
 
     await fetch('https://api.resend.com/emails', {
       method: 'POST',
@@ -96,9 +179,14 @@ export default async function handler(req: Request): Promise<Response> {
       }),
     });
 
-    return new Response(JSON.stringify({ ok: true, leadId }), { status: 200 });
+    return new Response(JSON.stringify({ ok: true, leadId }), {
+      status: 200,
+      headers: { ...cors, 'Content-Type': 'application/json' },
+    });
   } catch (err: any) {
-    return new Response(JSON.stringify({ error: 'Unexpected error' }), { status: 500 });
+    return new Response(JSON.stringify({ error: 'Unexpected error' }), {
+      status: 500,
+      headers: { ...cors, 'Content-Type': 'application/json' },
+    });
   }
 }
-

--- a/supabase/functions/track-event/index.ts
+++ b/supabase/functions/track-event/index.ts
@@ -1,5 +1,3 @@
-import { createClient } from '@supabase/supabase-js';
-
 const allowedEvents = [
   'form_view',
   'form_start',
@@ -10,39 +8,56 @@ const allowedEvents = [
   'cta_click',
 ];
 
+const ALLOW_ORIGIN = 'https://studio.anix-ai.pro';
+const cors = {
+  'Access-Control-Allow-Origin': ALLOW_ORIGIN,
+  'Access-Control-Allow-Headers': 'content-type',
+  'Access-Control-Allow-Methods': 'POST,OPTIONS,GET',
+};
+
 export default async function handler(req: Request): Promise<Response> {
-  const origin = req.headers.get('origin') || '';
-  const allowedOrigin = Deno.env.get('ALLOWED_ORIGIN') || process.env.ALLOWED_ORIGIN || '';
-  const headers: Record<string, string> = {
-    'Access-Control-Allow-Origin': allowedOrigin,
-    'Access-Control-Allow-Headers': 'content-type',
-  };
-
   if (req.method === 'OPTIONS') {
-    return new Response(null, { status: 200, headers });
-  }
-
-  if (origin !== allowedOrigin) {
-    return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403, headers });
+    return new Response(null, { status: 204, headers: cors });
   }
 
   if (req.method !== 'POST') {
-    return new Response(JSON.stringify({ error: 'Method not allowed' }), { status: 405, headers });
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { ...cors, 'Content-Type': 'application/json' },
+    });
   }
 
   try {
     const { event, leadId, meta } = await req.json();
     if (!allowedEvents.includes(event)) {
-      return new Response(JSON.stringify({ error: 'Unknown event' }), { status: 400, headers });
+      return new Response(JSON.stringify({ error: 'Unknown event' }), {
+        status: 400,
+        headers: { ...cors, 'Content-Type': 'application/json' },
+      });
     }
 
-    const supabaseUrl = Deno.env.get('SUPABASE_URL') || process.env.SUPABASE_URL;
-    const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') || process.env.SUPABASE_SERVICE_ROLE_KEY;
-    const supabase = createClient(supabaseUrl!, supabaseKey!);
-    const ip = req.headers.get('x-forwarded-for') || req.headers.get('cf-connecting-ip') || '';
+    const SB_URL = Deno.env.get('SB_URL') || process.env.SB_URL;
+    const SB_SERVICE_ROLE_KEY =
+      Deno.env.get('SB_SERVICE_ROLE_KEY') || process.env.SB_SERVICE_ROLE_KEY;
+
+    if (!SB_URL || !SB_SERVICE_ROLE_KEY) {
+      return new Response(JSON.stringify({ error: 'misconfigured' }), {
+        status: 500,
+        headers: { ...cors, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const { createClient } = await import(
+      'https://esm.sh/@supabase/supabase-js@2'
+    );
+    const sb = createClient(SB_URL, SB_SERVICE_ROLE_KEY);
+    const ip =
+      req.headers.get('x-forwarded-for') ||
+      req.headers.get('cf-connecting-ip') ||
+      '';
     const ua = req.headers.get('user-agent') || '';
 
-    const { error } = await supabase.from('lead_events').insert({
+    const { error } = await sb.from('lead_events').insert({
       event_name: event,
       lead_id: leadId || null,
       meta: meta || null,
@@ -50,10 +65,19 @@ export default async function handler(req: Request): Promise<Response> {
       ua,
     });
     if (error) {
-      return new Response(JSON.stringify({ error: 'Database error' }), { status: 500, headers });
+      return new Response(JSON.stringify({ error: 'Database error' }), {
+        status: 500,
+        headers: { ...cors, 'Content-Type': 'application/json' },
+      });
     }
-    return new Response(JSON.stringify({ ok: true }), { status: 200, headers });
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { ...cors, 'Content-Type': 'application/json' },
+    });
   } catch (err: any) {
-    return new Response(JSON.stringify({ error: 'Unexpected error' }), { status: 500, headers });
+    return new Response(JSON.stringify({ error: 'Unexpected error' }), {
+      status: 500,
+      headers: { ...cors, 'Content-Type': 'application/json' },
+    });
   }
 }


### PR DESCRIPTION
## Summary
- replace SUPABASE_* env vars with SB_URL and SB_SERVICE_ROLE_KEY in edge functions
- add shared CORS config and OPTIONS handler
- return `misconfigured` on missing required env

## Testing
- `npx prettier --write "supabase/functions/**/*.ts"`
- `npm test -- --watchAll=false` *(fails: Cannot find module 'https://deno.land/std@0.224.0/http/server.ts'...)*

------
https://chatgpt.com/codex/tasks/task_e_689b8eaf78e8832097574c14ed2dc393