### PR TITLE
Hide gradient separators between sections

### DIFF
--- a/src/components/SectionSeparator.tsx
+++ b/src/components/SectionSeparator.tsx
@@ -7,5 +7,8 @@ export default function SectionSeparator({
   position?: 'top' | 'bottom';
   variant?: 'gradient' | 'curve';
 }) {
+  if (variant === 'gradient') {
+    return null;
+  }
   return <div className={`sep sep--${position} sep--${variant}`} aria-hidden />;
 }


### PR DESCRIPTION
## Summary
- hide gradient separators between sections so they no longer render

## Testing
- `npm run lint`
- `npm test -- --watchAll=false` *(fails: Cannot find module 'https://deno.land/std@0.224.0/http/server.ts')*


------
https://chatgpt.com/codex/tasks/task_e_689b90439ac883208d3ee3db0d284dbe