### PR TITLE
Add config with Supabase fallbacks to avoid undefined POSTs

### DIFF
--- a/src/@/config.ts
+++ b/src/@/config.ts
@@ -1,0 +1,1 @@
+export { CONFIG, assertConfig } from '../config';

--- a/src/components/LeadForm.js
+++ b/src/components/LeadForm.js
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { track } from '../lib/analytics';
+import { CONFIG, assertConfig } from '@/config';
+assertConfig();
 
 const telegramPattern =
   /^(@?[a-zA-Z0-9_]{5,32}|https?:\/\/t\.me\/[a-zA-Z0-9_]{5,32}|tg:\/\/resolve\?domain=[a-zA-Z0-9_]{5,32})$/;
@@ -52,7 +54,19 @@ const LeadForm = () => {
       const utm = window.location.search;
       const referrer = document.referrer;
       const pathname = window.location.pathname;
-      const res = await fetch(process.env.NEXT_PUBLIC_SUBMIT_LEAD_URL, {
+      if (
+        !CONFIG.SUBMIT_LEAD_URL ||
+        CONFIG.SUBMIT_LEAD_URL.includes('undefined')
+      ) {
+        console.error(
+          '[Form] Misconfigured SUBMIT_LEAD_URL:',
+          CONFIG.SUBMIT_LEAD_URL
+        );
+        setToast('Ошибка конфигурации формы');
+        setLoading(false);
+        return;
+      }
+      const res = await fetch(CONFIG.SUBMIT_LEAD_URL, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -147,7 +161,7 @@ const LeadForm = () => {
         </div>
         <div
           className="cf-turnstile"
-          data-sitekey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY}
+          data-sitekey={CONFIG.TURNSTILE_SITE_KEY}
           data-callback={(token) =>
             setFormData((p) => ({ ...p, captchaToken: token }))
           }
@@ -167,7 +181,9 @@ const LeadForm = () => {
         </div>
       </form>
       {toast && (
-        <div className="mt-2 text-center text-sm text-white" role="status">{toast}</div>
+        <div className="mt-2 text-center text-sm text-white" role="status">
+          {toast}
+        </div>
       )}
       <a
         href="#"

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,21 @@
+// Публичный ref — НЕ секрет. Нужен фолбэк, чтобы не было /undefined.
+const PROJECT_REF = 'ppoygmaqlaiqcisjetea';
+const FALLBACK_SUBMIT = `https://${PROJECT_REF}.functions.supabase.co/submit-lead`;
+const FALLBACK_TRACK = `https://${PROJECT_REF}.functions.supabase.co/track-event`;
+
+export const CONFIG = {
+  SUBMIT_LEAD_URL: process.env.REACT_APP_SUBMIT_LEAD_URL || FALLBACK_SUBMIT,
+  TRACK_EVENT_URL: process.env.REACT_APP_TRACK_EVENT_URL || FALLBACK_TRACK,
+  TURNSTILE_SITE_KEY: process.env.REACT_APP_TURNSTILE_SITE_KEY || '',
+};
+
+export function assertConfig() {
+  const missing: string[] = [];
+  if (!process.env.REACT_APP_SUBMIT_LEAD_URL)
+    missing.push('REACT_APP_SUBMIT_LEAD_URL');
+  if (!process.env.REACT_APP_TRACK_EVENT_URL)
+    missing.push('REACT_APP_TRACK_EVENT_URL');
+  if (!CONFIG.TURNSTILE_SITE_KEY) missing.push('REACT_APP_TURNSTILE_SITE_KEY');
+  if (missing.length)
+    console.warn('[CFG] Using FALLBACK URLs. Missing:', missing.join(', '));
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,7 @@
 import React from 'react';
+import { CONFIG } from '@/config';
+console.info('[CFG] SUBMIT:', CONFIG.SUBMIT_LEAD_URL);
+console.info('[CFG] TRACK :', CONFIG.TRACK_EVENT_URL);
 import ReactDOM from 'react-dom/client';
 import './App.css';
 import './styles/sections.css';

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,5 +1,7 @@
+import { CONFIG } from '@/config';
+
 export async function track(event: string, payload: Record<string, any> = {}) {
-  const url = process.env.NEXT_PUBLIC_TRACK_EVENT_URL;
+  const url = CONFIG.TRACK_EVENT_URL;
   if (!url) return;
   try {
     await fetch(url, {


### PR DESCRIPTION
## Summary
- centralize configuration with Supabase fallbacks for submit and tracking
- use CONFIG across app with guard against misconfigured URLs
- add temporary runtime config logging for diagnostics

## Testing
- `npm test -- --watchAll=false` *(fails: submit-lead test expected 200 but got 500; email-open module missing)*
- `npm run build`
- `grep -ao "functions.supabase.co/submit-lead" build/static/js/main*.js`
- `grep -ao "/track-event" build/static/js/main*.js`


------
https://chatgpt.com/codex/tasks/task_e_689c32d1dbd88320ad02bba252edda3d