### PR TITLE
feat: robust form submission and cors

### DIFF
--- a/src/__tests__/functions.test.js
+++ b/src/__tests__/functions.test.js
@@ -90,7 +90,7 @@ describe('submit-lead', () => {
   });
 
   test('success returns leadId', async () => {
-    jest.doMock('@supabase/supabase-js', () => ({
+    jest.doMock('https://esm.sh/@supabase/supabase-js@2', () => ({
       createClient: () => ({
         from: () => ({
           insert: () => ({
@@ -105,8 +105,8 @@ describe('submit-lead', () => {
     const submitLead =
       require('../../supabase/functions/submit-lead/index.js').default;
     process.env.TURNSTILE_SECRET_KEY = 'secret';
-    process.env.SUPABASE_URL = 'https://example.supabase.co';
-    process.env.SUPABASE_SERVICE_ROLE_KEY = 'role';
+    process.env.SB_URL = 'https://example.supabase.co';
+    process.env.SB_SERVICE_ROLE_KEY = 'role';
     process.env.RESEND_API_KEY = 'resend';
     global.fetch = jest.fn((url) => {
       if (url.includes('turnstile')) {
@@ -114,7 +114,7 @@ describe('submit-lead', () => {
           json: () => Promise.resolve({ success: true }),
         });
       }
-      return Promise.resolve({ json: () => Promise.resolve({}) });
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
     });
     const req = new Request('https://example.com', {
       method: 'POST',
@@ -137,7 +137,7 @@ describe('submit-lead', () => {
   });
 
   test('captcha fail returns 400', async () => {
-    jest.doMock('@supabase/supabase-js', () => ({
+    jest.doMock('https://esm.sh/@supabase/supabase-js@2', () => ({
       createClient: () => ({
         from: () => ({
           insert: () => ({
@@ -175,11 +175,13 @@ describe('submit-lead', () => {
 
 describe('email-open', () => {
   test('returns png', async () => {
-    jest.doMock('@supabase/supabase-js', () => ({
+    jest.doMock('https://esm.sh/@supabase/supabase-js@2', () => ({
       createClient: () => ({
         from: () => ({ insert: () => Promise.resolve({ error: null }) }),
       }),
     }));
+    process.env.SB_URL = 'https://example.supabase.co';
+    process.env.SB_SERVICE_ROLE_KEY = 'role';
     const emailOpen =
       require('../../supabase/functions/email-open/index.js').default;
     const req = new Request('https://example.com?lead_id=abc');

--- a/src/components/LeadForm.tsx
+++ b/src/components/LeadForm.tsx
@@ -1,12 +1,50 @@
-import React, { useState, useEffect } from 'react';
-import { track } from '../lib/analytics';
+import React, { useEffect, useState } from 'react';
 import { CONFIG, assertConfig } from '@/config';
-assertConfig();
+import { track } from '../lib/analytics';
+
+function withTimeout<T>(p: Promise<T>, ms = 15000) {
+  const ac = new AbortController();
+  const t = setTimeout(() => ac.abort(), ms);
+  return Promise.race([
+    p.finally(() => clearTimeout(t)),
+    new Promise<T>((_, rej) =>
+      ac.signal.addEventListener('abort', () => rej(new Error('timeout')))
+    ),
+  ]) as Promise<T>;
+}
+
+async function submitLead(payload: any) {
+  if (!CONFIG.SUBMIT_LEAD_URL || CONFIG.SUBMIT_LEAD_URL.includes('undefined')) {
+    throw new Error('misconfigured');
+  }
+  try {
+    const res = await withTimeout(
+      fetch(CONFIG.SUBMIT_LEAD_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+    );
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      const msg = data?.error || data?.message || `HTTP ${res.status}`;
+      const err: any = new Error(String(msg));
+      err.code = res.status;
+      throw err;
+    }
+    return data;
+  } catch (e: any) {
+    if (e?.name === 'AbortError' || e?.message === 'timeout')
+      throw new Error('network_timeout');
+    if (e?.message === 'Failed to fetch') throw new Error('network_failed');
+    throw e;
+  }
+}
 
 const telegramPattern =
   /^(@?[a-zA-Z0-9_]{5,32}|https?:\/\/t\.me\/[a-zA-Z0-9_]{5,32}|tg:\/\/resolve\?domain=[a-zA-Z0-9_]{5,32})$/;
 
-const LeadForm = () => {
+const LeadForm: React.FC = () => {
   const [formData, setFormData] = useState({
     email: '',
     position: '',
@@ -16,10 +54,11 @@ const LeadForm = () => {
   });
   const [started, setStarted] = useState(false);
   const [submitted, setSubmitted] = useState(false);
-  const [toast, setToast] = useState('');
-  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [errorText, setErrorText] = useState<string | null>(null);
 
   useEffect(() => {
+    assertConfig();
     const utm = window.location.search;
     const referrer = document.referrer;
     const pathname = window.location.pathname;
@@ -33,7 +72,7 @@ const LeadForm = () => {
     }
   };
 
-  const handleChange = (e) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value, type, checked } = e.target;
     onFirstInput();
     setFormData((prev) => ({
@@ -42,56 +81,63 @@ const LeadForm = () => {
     }));
   };
 
-  const handleSubmit = async (e) => {
+  async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
+    setErrorText(null);
+    setSubmitting(true);
     const { email, position, telegram, consent, captchaToken } = formData;
-    if (!email || !position || !telegramPattern.test(telegram) || !consent) {
-      setToast('Проверьте форму');
+    if (!captchaToken) {
+      setErrorText('Подтвердите, что вы не бот (капча).');
+      track('form_error', { kind: 'captcha', raw: 'missing_token' });
+      setSubmitting(false);
       return;
     }
-    setLoading(true);
-    try {
-      const utm = window.location.search;
-      const referrer = document.referrer;
-      const pathname = window.location.pathname;
-      if (
-        !CONFIG.SUBMIT_LEAD_URL ||
-        CONFIG.SUBMIT_LEAD_URL.includes('undefined')
-      ) {
-        console.error(
-          '[Form] Misconfigured SUBMIT_LEAD_URL:',
-          CONFIG.SUBMIT_LEAD_URL
-        );
-        setToast('Ошибка конфигурации формы');
-        setLoading(false);
-        return;
-      }
-      const res = await fetch(CONFIG.SUBMIT_LEAD_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          email,
-          position,
-          telegram,
-          consent,
-          captchaToken,
-          utm,
-          referrer,
-          pathname,
-        }),
-      });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || 'Ошибка');
-      track('form_submit', { leadId: data.leadId });
-      setSubmitted(true);
-      setToast('Спасибо! Чек-лист отправлен вам на почту.');
-    } catch (err) {
-      setToast(err.message);
-    } finally {
-      setLoading(false);
-      setTimeout(() => setToast(''), 4000);
+    if (!telegramPattern.test(telegram)) {
+      setErrorText('Некорректный Telegram.');
+      track('form_error', { kind: 'telegram', raw: telegram });
+      setSubmitting(false);
+      return;
     }
-  };
+    const utm = window.location.search;
+    const referrer = document.referrer;
+    const pathname = window.location.pathname;
+    const payload = {
+      email,
+      position,
+      telegram,
+      consent,
+      captchaToken,
+      utm,
+      referrer,
+      pathname,
+    };
+    try {
+      const data = await submitLead(payload);
+      track('form_submit', { leadId: data?.leadId });
+      setSubmitted(true);
+      // here could clear form if needed
+    } catch (err: any) {
+      let msg = 'Не удалось отправить. Попробуйте обновить страницу.';
+      let kind: string = 'server';
+      if (err?.message === 'misconfigured') {
+        msg = 'Неверная конфигурация формы (URL).';
+        kind = 'config';
+      } else if (err?.message === 'network_timeout') {
+        msg = 'Сервер долго не отвечает. Попробуйте ещё раз.';
+        kind = 'network_timeout';
+      } else if (err?.message === 'network_failed') {
+        msg = 'Сеть недоступна или CORS. Проверьте подключение.';
+        kind = 'network_failed';
+      } else if (err?.code === 400 && /captcha/i.test(err?.message)) {
+        msg = 'Не прошла проверка капчи. Обновите страницу.';
+        kind = 'captcha';
+      }
+      setErrorText(msg);
+      track('form_error', { kind, raw: String(err?.message || err) });
+    } finally {
+      setSubmitting(false);
+    }
+  }
 
   if (submitted) {
     return (
@@ -103,7 +149,7 @@ const LeadForm = () => {
 
   return (
     <>
-      <form onSubmit={handleSubmit} className="space-y-4">
+      <form onSubmit={onSubmit} className="space-y-4">
         <div>
           <label className="block text-sm mb-1" htmlFor="email">
             Email*
@@ -162,29 +208,29 @@ const LeadForm = () => {
         <div
           className="cf-turnstile"
           data-sitekey={CONFIG.TURNSTILE_SITE_KEY}
-          data-callback={(token) =>
+          data-callback={(token: string) =>
             setFormData((p) => ({ ...p, captchaToken: token }))
           }
         />
         <div className="space-y-1">
           <button
             type="submit"
-            disabled={loading}
+            disabled={submitting}
             className="w-full bg-anix-purple hover:bg-anix-teal text-white py-2 rounded transition-colors disabled:opacity-50"
           >
-            {loading ? 'Отправка...' : '📩 Получить чек-лист в Telegram'}
+            {submitting ? 'Отправка...' : '📩 Получить чек-лист в Telegram'}
           </button>
+          {errorText && (
+            <div className="mt-2 text-center text-sm text-white" role="status">
+              {errorText}
+            </div>
+          )}
           <p className="text-sm text-[#B0B0B0] text-center">
             Чек-лист придёт в Telegram, а при желании разберём его вместе с
             вами.
           </p>
         </div>
       </form>
-      {toast && (
-        <div className="mt-2 text-center text-sm text-white" role="status">
-          {toast}
-        </div>
-      )}
       <a
         href="#"
         className="block text-center text-xs text-gray-400 underline mt-2"

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -3,13 +3,19 @@ import { CONFIG } from '@/config';
 export async function track(event: string, payload: Record<string, any> = {}) {
   const url = CONFIG.TRACK_EVENT_URL;
   if (!url) return;
-  try {
-    await fetch(url, {
+
+  const send = () =>
+    fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ event, meta: payload }),
     });
+
+  try {
+    await send();
   } catch {
-    // ignore
+    setTimeout(() => {
+      send().catch(() => {});
+    }, 1000);
   }
 }

--- a/supabase/functions/submit-lead/index.ts
+++ b/supabase/functions/submit-lead/index.ts
@@ -1,12 +1,19 @@
+const ORIGIN = 'https://studio.anix-ai.pro';
+const CORS = {
+  'Access-Control-Allow-Origin': ORIGIN,
+  'Access-Control-Allow-Headers': 'content-type',
+  'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+};
+
+function json(body: any, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...CORS },
+  });
+}
+
 const telegramRegex =
   /^(@?[a-zA-Z0-9_]{5,32}|https?:\/\/t\.me\/[a-zA-Z0-9_]{5,32}|tg:\/\/resolve\?domain=[a-zA-Z0-9_]{5,32})$/;
-
-const ALLOW_ORIGIN = 'https://studio.anix-ai.pro';
-const cors = {
-  'Access-Control-Allow-Origin': ALLOW_ORIGIN,
-  'Access-Control-Allow-Headers': 'content-type',
-  'Access-Control-Allow-Methods': 'POST,OPTIONS,GET',
-};
 
 function buildTags(email: string, position: string): string[] {
   const tags: string[] = [];
@@ -41,17 +48,9 @@ function buildTags(email: string, position: string): string[] {
   return Array.from(new Set(tags));
 }
 
-export default async function handler(req: Request): Promise<Response> {
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { status: 204, headers: cors });
-  }
-
-  if (req.method !== 'POST') {
-    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
-      status: 405,
-      headers: { ...cors, 'Content-Type': 'application/json' },
-    });
-  }
+async function handler(req: Request): Promise<Response> {
+  if (req.method === 'OPTIONS') return new Response(null, { status: 204, headers: CORS });
+  if (req.method !== 'POST') return json({ error: 'method_not_allowed' }, 405);
 
   try {
     const {
@@ -71,57 +70,27 @@ export default async function handler(req: Request): Promise<Response> {
       !telegramRegex.test(telegram) ||
       consent !== true
     ) {
-      return new Response(JSON.stringify({ error: 'Invalid input' }), {
-        status: 400,
-        headers: { ...cors, 'Content-Type': 'application/json' },
-      });
+      return json({ error: 'invalid_input' }, 400);
     }
 
-    const turnstileSecret =
-      Deno.env.get('TURNSTILE_SECRET_KEY') || process.env.TURNSTILE_SECRET_KEY;
-    if (!turnstileSecret) {
-      return new Response(JSON.stringify({ error: 'misconfigured' }), {
-        status: 500,
-        headers: { ...cors, 'Content-Type': 'application/json' },
-      });
-    }
+    const turnstileSecret = Deno.env.get('TURNSTILE_SECRET_KEY') ||
+      process.env.TURNSTILE_SECRET_KEY;
+    if (!turnstileSecret) return json({ error: 'misconfigured' }, 500);
 
-    const turnRes = await fetch(
-      'https://challenges.cloudflare.com/turnstile/v0/siteverify',
-      {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          secret: turnstileSecret,
-          response: captchaToken,
-        }),
-      }
-    );
+    const turnRes = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ secret: turnstileSecret, response: captchaToken }),
+    });
     const turnJson = await turnRes.json();
-    if (!turnJson.success) {
-      return new Response(
-        JSON.stringify({ error: 'Captcha verification failed' }),
-        {
-          status: 400,
-          headers: { ...cors, 'Content-Type': 'application/json' },
-        }
-      );
-    }
+    if (!turnJson.success) return json({ error: 'Captcha verification failed' }, 400);
 
     const SB_URL = Deno.env.get('SB_URL') || process.env.SB_URL;
     const SB_SERVICE_ROLE_KEY =
       Deno.env.get('SB_SERVICE_ROLE_KEY') || process.env.SB_SERVICE_ROLE_KEY;
+    if (!SB_URL || !SB_SERVICE_ROLE_KEY) return json({ error: 'misconfigured' }, 500);
 
-    if (!SB_URL || !SB_SERVICE_ROLE_KEY) {
-      return new Response(JSON.stringify({ error: 'misconfigured' }), {
-        status: 500,
-        headers: { ...cors, 'Content-Type': 'application/json' },
-      });
-    }
-
-    const { createClient } = await import(
-      'https://esm.sh/@supabase/supabase-js@2'
-    );
+    const { createClient } = await import('https://esm.sh/@supabase/supabase-js@2');
     const sb = createClient(SB_URL, SB_SERVICE_ROLE_KEY);
 
     const ip =
@@ -145,27 +114,17 @@ export default async function handler(req: Request): Promise<Response> {
       .select()
       .single();
 
-    if (error) {
-      return new Response(JSON.stringify({ error: 'Database error' }), {
-        status: 500,
-        headers: { ...cors, 'Content-Type': 'application/json' },
-      });
-    }
+    if (error) return json({ error: 'Database error' }, 500);
 
     const leadId = data.id;
-    const resendKey =
-      Deno.env.get('RESEND_API_KEY') || process.env.RESEND_API_KEY;
-    if (!resendKey) {
-      return new Response(JSON.stringify({ error: 'misconfigured' }), {
-        status: 500,
-        headers: { ...cors, 'Content-Type': 'application/json' },
-      });
-    }
+    const resendKey = Deno.env.get('RESEND_API_KEY') || process.env.RESEND_API_KEY;
+    if (!resendKey) return json({ error: 'misconfigured' }, 500);
+
     const htmlContent =
       `<p>Спасибо за интерес!</p>` +
       `<img src="${SB_URL}/functions/v1/email-open?lead_id=${leadId}&t=${Date.now()}" width="1" height="1" style="display:none" alt="">`;
 
-    await fetch('https://api.resend.com/emails', {
+    const emailRes = await fetch('https://api.resend.com/emails', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -178,15 +137,18 @@ export default async function handler(req: Request): Promise<Response> {
         html: htmlContent,
       }),
     });
+    if (!emailRes.ok) {
+      const detail = await emailRes.text().catch(() => '');
+      return json({ error: 'resend_error', detail }, 502);
+    }
 
-    return new Response(JSON.stringify({ ok: true, leadId }), {
-      status: 200,
-      headers: { ...cors, 'Content-Type': 'application/json' },
-    });
-  } catch (err: any) {
-    return new Response(JSON.stringify({ error: 'Unexpected error' }), {
-      status: 500,
-      headers: { ...cors, 'Content-Type': 'application/json' },
-    });
+    return json({ ok: true, leadId });
+  } catch (err) {
+    return json({ error: 'Unexpected error' }, 500);
   }
 }
+
+if (typeof Deno !== 'undefined' && typeof (Deno as any).serve === 'function') {
+  (Deno as any).serve(handler);
+}
+export default handler;


### PR DESCRIPTION
## Summary
- strengthen lead form submit with config validation, timeouts and friendly errors
- retry analytics events and centralize supabase URLs
- unify CORS/JSON responses in edge functions

## Testing
- `npm run build`
- `CI=true npm test` *(fails: Cannot find module 'https://esm.sh/@supabase/supabase-js@2')*


------
https://chatgpt.com/codex/tasks/task_e_689c36e104648320b8065969ed5abc04