### PR TITLE
Add workflow for deploying Supabase edge functions

### DIFF
--- a/.github/workflows/supabase-functions.yml
+++ b/.github/workflows/supabase-functions.yml
@@ -1,0 +1,27 @@
+name: Deploy Supabase Edge Functions
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'supabase/functions/**'
+  workflow_dispatch:
+
+jobs:
+  deploy-functions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v1
+        with: { deno-version: v1.x }
+      - uses: supabase/setup-cli@v1
+      - name: Link to Supabase project
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+        run: supabase link --project-ref ppoygmaqlaiqcisjetea
+      - name: Deploy all functions
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+        run: |
+          supabase functions deploy track-event
+          supabase functions deploy submit-lead
+          supabase functions deploy email-open


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy Supabase Edge Functions on push to main or manual trigger

## Testing
- `npm test -- --watch=false`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ca2b6cf408320806bbbfbf7f8e2ef