### PR TITLE
feat: add supabase anon key support

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -45,6 +45,12 @@ jobs:
 
       - name: Build
         if: steps.npm-install.outcome == 'success'
+        env:
+          REACT_APP_SUBMIT_LEAD_URL: ${{ secrets.REACT_APP_SUBMIT_LEAD_URL }}
+          REACT_APP_TRACK_EVENT_URL: ${{ secrets.REACT_APP_TRACK_EVENT_URL }}
+          REACT_APP_TURNSTILE_SITE_KEY: ${{ secrets.REACT_APP_TURNSTILE_SITE_KEY }}
+          REACT_APP_SUPABASE_ANON_KEY: ${{ secrets.REACT_APP_SUPABASE_ANON_KEY }}
+          CI: false
         run: npm run build
 
       - name: Prepare 404 page

--- a/src/components/LeadForm.tsx
+++ b/src/components/LeadForm.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { CONFIG, assertConfig } from '@/config';
 import { track } from '../lib/analytics';
+import { postJson } from '../lib/net';
 
 function withTimeout<T>(p: Promise<T>, ms = 15000) {
   const ac = new AbortController();
@@ -18,20 +19,7 @@ async function submitLead(payload: any) {
     throw new Error('misconfigured');
   }
   try {
-    const res = await withTimeout(
-      fetch(CONFIG.SUBMIT_LEAD_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      })
-    );
-    const data = await res.json().catch(() => ({}));
-    if (!res.ok) {
-      const msg = data?.error || data?.message || `HTTP ${res.status}`;
-      const err: any = new Error(String(msg));
-      err.code = res.status;
-      throw err;
-    }
+    const data = await withTimeout(postJson(CONFIG.SUBMIT_LEAD_URL, payload));
     return data;
   } catch (e: any) {
     if (e?.name === 'AbortError' || e?.message === 'timeout')

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ export const CONFIG = {
   SUBMIT_LEAD_URL: process.env.REACT_APP_SUBMIT_LEAD_URL || FALLBACK_SUBMIT,
   TRACK_EVENT_URL: process.env.REACT_APP_TRACK_EVENT_URL || FALLBACK_TRACK,
   TURNSTILE_SITE_KEY: process.env.REACT_APP_TURNSTILE_SITE_KEY || '',
+  SUPABASE_ANON_KEY: process.env.REACT_APP_SUPABASE_ANON_KEY || '',
 };
 
 export function assertConfig() {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,15 +1,11 @@
 import { CONFIG } from '@/config';
+import { postJson } from './net';
 
 export async function track(event: string, payload: Record<string, any> = {}) {
   const url = CONFIG.TRACK_EVENT_URL;
   if (!url) return;
 
-  const send = () =>
-    fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ event, meta: payload }),
-    });
+  const send = () => postJson(url, { event, meta: payload });
 
   try {
     await send();

--- a/src/lib/net.ts
+++ b/src/lib/net.ts
@@ -1,0 +1,35 @@
+import { CONFIG } from '@/config';
+
+function isSupabaseFn(url: string) {
+  try {
+    return new URL(url).hostname.endsWith('.functions.supabase.co');
+  } catch {
+    return false;
+  }
+}
+
+export async function postJson(url: string, body: any) {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (isSupabaseFn(url) && CONFIG.SUPABASE_ANON_KEY) {
+    headers['Authorization'] = `Bearer ${CONFIG.SUPABASE_ANON_KEY}`;
+    headers['apikey'] = CONFIG.SUPABASE_ANON_KEY;
+  }
+  const r = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+  let data: any = null;
+  try {
+    data = await r.json();
+  } catch {}
+  if (!r.ok || (data && data.error)) {
+    const err: any = new Error(data?.error || r.statusText);
+    err.detail = data?.detail;
+    err.code = r.status;
+    throw err;
+  }
+  return data;
+}

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,0 +1,7 @@
+const ORIGIN = 'https://studio.anix-ai.pro';
+export const ALLOWED_HEADERS = 'content-type, authorization, x-client-info, apikey';
+export const CORS = {
+  'Access-Control-Allow-Origin': ORIGIN,
+  'Access-Control-Allow-Headers': ALLOWED_HEADERS,
+  'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+};

--- a/supabase/functions/email-open/index.ts
+++ b/supabase/functions/email-open/index.ts
@@ -1,9 +1,4 @@
-const ORIGIN = 'https://studio.anix-ai.pro';
-const CORS = {
-  'Access-Control-Allow-Origin': ORIGIN,
-  'Access-Control-Allow-Headers': 'content-type',
-  'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
-};
+import { CORS } from '../_shared/cors.ts';
 
 function json(body: any, status = 200) {
   return new Response(JSON.stringify(body), {

--- a/supabase/functions/submit-lead/index.ts
+++ b/supabase/functions/submit-lead/index.ts
@@ -1,9 +1,4 @@
-const ORIGIN = 'https://studio.anix-ai.pro';
-const CORS = {
-  'Access-Control-Allow-Origin': ORIGIN,
-  'Access-Control-Allow-Headers': 'content-type',
-  'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
-};
+import { CORS } from '../_shared/cors.ts';
 
 function json(body: any, status = 200) {
   return new Response(JSON.stringify(body), {

--- a/supabase/functions/track-event/index.ts
+++ b/supabase/functions/track-event/index.ts
@@ -1,9 +1,4 @@
-const ORIGIN = 'https://studio.anix-ai.pro';
-const CORS = {
-  'Access-Control-Allow-Origin': ORIGIN,
-  'Access-Control-Allow-Headers': 'content-type',
-  'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
-};
+import { CORS } from '../_shared/cors.ts';
 
 function json(body: any, status = 200) {
   return new Response(JSON.stringify(body), {


### PR DESCRIPTION
## Summary
- support SUPABASE_ANON_KEY in client config
- automatically send Supabase auth headers for function calls
- centralize Supabase function CORS and allow auth headers
- expose anon key in Pages workflow

## Testing
- `npm run lint`
- `npm test -- --watchAll=false` *(fails: Cannot find module 'https://esm.sh/@supabase/supabase-js@2')*
- `npx supabase functions deploy track-event` *(fails: 403 Forbidden - GET https://registry.npmjs.org/supabase)*
- `npx supabase functions deploy submit-lead` *(fails: 403 Forbidden - GET https://registry.npmjs.org/supabase)*
- `npx supabase functions deploy email-open` *(fails: 403 Forbidden - GET https://registry.npmjs.org/supabase)*

------
https://chatgpt.com/codex/tasks/task_e_689ca90d0c2883209baabfb8d164b76b