### PR TITLE
Remove section dividers between sections

### DIFF
--- a/src/components/StickyBridge.tsx
+++ b/src/components/StickyBridge.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 export default function StickyBridge() {
-  return <div className="sticky-bridge" aria-hidden />;
+  return null;
 }


### PR DESCRIPTION
## Summary
- Hide sticky bridge placeholder to eliminate empty bands between landing page sections.

## Testing
- `npm test -- --watchAll=false`
- `npm run lint`
- `npm run lint:css` *(fails: TypeError: prettier.resolveConfig.sync is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689dc65fe39c8320ab6fa07651500ebe