### PR TITLE
Remove hero play button overlay and adjust testimonials text

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -135,6 +135,10 @@ body {
   font-size: 24px;
 }
 
+.hero-background .lite-vimeo-play {
+  display: none;
+}
+
 .hero-overlay {
   position: absolute;
   top: 0;

--- a/src/App.js
+++ b/src/App.js
@@ -846,7 +846,7 @@ const AnixAILanding = () => {
                       </div>
                     </div>
                     <div className="testimonial-content">
-                      <p>&quot;{previewText}&quot;</p>
+                      <p>{previewText}</p>
                       <div className="testimonial-author">
                         <strong>{testimonial.name}</strong>
                         {testimonial.website ? (


### PR DESCRIPTION
## Summary
- hide the LiteVimeo play control when used in the hero background so the play button no longer shows behind the rotating message
- remove the surrounding quotation marks from testimonial preview text for cleaner presentation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc27d14d408320a37dfc40b3975ab4