### PR TITLE
Reorder NDA section and remove roadmap block

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,9 +2,6 @@ import React, { useState, useEffect, useRef, Suspense } from 'react';
 import './App.css';
 import Section from './components/Section';
 import LiteVimeo from './components/LiteVimeo';
-const AnixLandingPage = React.lazy(
-  () => import('./components/AnixLandingPage')
-);
 import { SectionAnixTech } from './components/SectionAnixTech';
 import god from './images/god.jpg';
 import bestie from './images/bestie.jpg';
@@ -63,7 +60,7 @@ const AnixAILanding = () => {
       formProductPlaceholder:
         'Кто ваша аудитория и какую задачу решает продукт',
       formSubmit: 'Получить анализ бесплатно',
-      audienceTitle: 'К кому мы подходим',
+      audienceTitle: 'Кому мы подходим',
       audienceSubtitle:
         'Мы работаем там, где продукт сложный, объяснения важнее эстетики',
       audienceCards: [
@@ -1372,6 +1369,38 @@ const AnixAILanding = () => {
         </div>
       </Section>
 
+      {/* NDA Cases Section */}
+      <Section id="nda" bg="#0f0f0f" className="nda-cases-section">
+        <div className="container">
+          <h2 className="section-title">{copy.ndaTitle}</h2>
+          <div className="nda-grid">
+            {ndaCases.map((item, index) => (
+              <div key={index} className="nda-card">
+                <div className="nda-card-header">
+                  <p className="nda-area">{item.area}</p>
+                  <span className="nda-pill">
+                    {t('Было → Стало', 'Before → After')}
+                  </span>
+                </div>
+                <div className="nda-card-body">
+                  <div className="nda-stat">
+                    <p className="nda-label">{t('До', 'Before')}</p>
+                    <p className="nda-value">{item.before}</p>
+                  </div>
+                  <div className="nda-divider" aria-hidden="true"></div>
+                  <div className="nda-stat">
+                    <p className="nda-label nda-label-strong">
+                      {t('После', 'After')}
+                    </p>
+                    <p className="nda-value nda-value-strong">{item.after}</p>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </Section>
+
       {/* Audience Fit Section */}
       <Section id="audience" bg="#0f0f1f" className="audience-section">
         <div className="container">
@@ -1571,11 +1600,6 @@ const AnixAILanding = () => {
           )}
         </p>
       </div>
-
-      {/*  👉 ставим Roadmap ЗА пределами .container */}
-      <Suspense fallback={null}>
-        <AnixLandingPage />
-      </Suspense>
 
       {/* Enhanced Awards Section */}
       <Section id="awards" bg="#2d1b3d" className="awards-section">
@@ -1879,38 +1903,6 @@ const AnixAILanding = () => {
                 <span>{t('Фев 2025', 'Feb 2025')}</span>
               </div>
             </a>
-          </div>
-        </div>
-      </Section>
-
-      {/* NDA Cases Section (moved below news) */}
-      <Section id="nda" bg="#0f0f0f" className="nda-cases-section">
-        <div className="container">
-          <h2 className="section-title">{copy.ndaTitle}</h2>
-          <div className="nda-grid">
-            {ndaCases.map((item, index) => (
-              <div key={index} className="nda-card">
-                <div className="nda-card-header">
-                  <p className="nda-area">{item.area}</p>
-                  <span className="nda-pill">
-                    {t('Было → Стало', 'Before → After')}
-                  </span>
-                </div>
-                <div className="nda-card-body">
-                  <div className="nda-stat">
-                    <p className="nda-label">{t('До', 'Before')}</p>
-                    <p className="nda-value">{item.before}</p>
-                  </div>
-                  <div className="nda-divider" aria-hidden="true"></div>
-                  <div className="nda-stat">
-                    <p className="nda-label nda-label-strong">
-                      {t('После', 'After')}
-                    </p>
-                    <p className="nda-value nda-value-strong">{item.after}</p>
-                  </div>
-                </div>
-              </div>
-            ))}
           </div>
         </div>
       </Section>


### PR DESCRIPTION
## Summary
- remove the roadmap/animation section by dropping the AnixLandingPage rendering
- move the NDA cases block directly after client cases
- adjust the audience heading copy

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693025d717148320ada124b15909a7c3)