### PR TITLE
Optimize Rybki landing LCP and slide delivery

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -23,15 +23,30 @@
 
     <link rel="icon" href="%PUBLIC_URL%/anix_wand.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <link
-      rel="preload"
-      as="image"
-      type="image/webp"
-      href="%PUBLIC_URL%/optimized/showreel-640.webp"
-      imagesrcset="%PUBLIC_URL%/optimized/showreel-640.webp 640w, %PUBLIC_URL%/optimized/showreel-960.webp 960w, %PUBLIC_URL%/optimized/showreel-1344.webp 1344w"
-      imagesizes="(max-width: 760px) 90vw, 48vw"
-      fetchpriority="high"
-    />
+    <script>
+      (function preloadRouteLcp() {
+        var path = window.location.pathname.replace(/\/+$/, '') || '/';
+        var link = document.createElement('link');
+        link.rel = 'preload';
+        link.as = 'image';
+        link.type = 'image/webp';
+        link.fetchPriority = 'high';
+
+        if (path === '/rybki') {
+          link.href = '%PUBLIC_URL%/optimized/rybki-01-cover-640.webp';
+          link.imageSrcset = '%PUBLIC_URL%/optimized/rybki-01-cover-640.webp 640w, %PUBLIC_URL%/optimized/rybki-01-cover-1280.webp 1280w, %PUBLIC_URL%/optimized/rybki-01-cover-1920.webp 1920w';
+          link.imageSizes = '(max-width: 800px) 94vw, calc(96vw - 174px)';
+        } else if (path === '/') {
+          link.href = '%PUBLIC_URL%/optimized/showreel-640.webp';
+          link.imageSrcset = '%PUBLIC_URL%/optimized/showreel-640.webp 640w, %PUBLIC_URL%/optimized/showreel-960.webp 960w, %PUBLIC_URL%/optimized/showreel-1344.webp 1344w';
+          link.imageSizes = '(max-width: 760px) 90vw, 48vw';
+        } else {
+          return;
+        }
+
+        document.head.appendChild(link);
+      })();
+    </script>
     <style>
       body{margin:0;font-family:system-ui,-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;background:#f7f4ef;color:#111;line-height:1.6;overflow-x:hidden}
     </style>

--- a/scripts/check-image-budget.js
+++ b/scripts/check-image-budget.js
@@ -6,6 +6,9 @@ const limits = [
   { file: 'public/optimized/showreel-640.webp', maxKiB: 220 },
   { file: 'public/optimized/showreel-960.webp', maxKiB: 360 },
   { file: 'public/optimized/showreel-1344.webp', maxKiB: 560 },
+  { file: 'public/optimized/rybki-01-cover-640.webp', maxKiB: 320 },
+  { file: 'public/optimized/rybki-01-cover-1280.webp', maxKiB: 700 },
+  { file: 'public/optimized/rybki-01-cover-1920.webp', maxKiB: 1200 },
 ];
 
 let failed = false;

--- a/scripts/optimize-assets.js
+++ b/scripts/optimize-assets.js
@@ -3,31 +3,53 @@ const path = require('path');
 const sharp = require('sharp');
 
 const root = path.resolve(__dirname, '..');
-const source = path.join(root, 'src', 'images', '3.png');
 const outputDir = path.join(root, 'public', 'optimized');
-const widths = [640, 960, 1344];
+const showreelSource = path.join(root, 'src', 'images', '3.png');
+const showreelWidths = [640, 960, 1344];
+const rybkiWidths = [640, 1280, 1920];
+const rybkiSlides = [
+  '01-cover',
+  '02-logline',
+  '03-why-it-hooks',
+  '04-synopsis',
+  '05-main-character',
+  '06-world',
+  '08-audience',
+  '09-potential',
+];
 
-async function main() {
-  fs.mkdirSync(outputDir, { recursive: true });
-
+async function optimizeResponsive(source, basename, widths, quality) {
   const metadata = await sharp(source).metadata();
   if (!metadata.width || !metadata.height) {
-    throw new Error('Cannot read showreel poster dimensions');
+    throw new Error(`Cannot read dimensions for ${source}`);
   }
 
   for (const width of widths) {
-    const output = path.join(outputDir, `showreel-${width}.webp`);
-    await sharp(source)
+    const output = path.join(outputDir, `${basename}-${width}.webp`);
+    await sharp(source, { density: 144 })
       .resize({ width, withoutEnlargement: true })
-      .webp({ quality: 78, effort: 6 })
+      .webp({ quality, effort: 6 })
       .toFile(output);
 
     const bytes = fs.statSync(output).size;
     console.log(`[assets] ${path.basename(output)} ${(bytes / 1024).toFixed(1)} KiB`);
   }
+}
 
-  const sourceBytes = fs.statSync(source).size;
-  console.log(`[assets] source poster ${(sourceBytes / 1024).toFixed(1)} KiB`);
+async function main() {
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  await optimizeResponsive(showreelSource, 'showreel', showreelWidths, 78);
+  console.log(`[assets] source poster ${(fs.statSync(showreelSource).size / 1024).toFixed(1)} KiB`);
+
+  for (const slide of rybkiSlides) {
+    const source = path.join(root, 'public', 'rybki-assets', `${slide}.svg`);
+    if (!fs.existsSync(source)) {
+      throw new Error(`Missing Rybki source slide: ${source}`);
+    }
+    await optimizeResponsive(source, `rybki-${slide}`, rybkiWidths, 80);
+    console.log(`[assets] source ${slide}.svg ${(fs.statSync(source).size / 1024).toFixed(1)} KiB`);
+  }
 }
 
 main().catch((error) => {

--- a/src/components/RybkiPage.jsx
+++ b/src/components/RybkiPage.jsx
@@ -6,18 +6,20 @@ import './RybkiPage.css';
 const telegramUrl = 'https://t.me/anix_helper';
 
 const slides = [
-  { src: '/rybki-assets/01-cover.svg', alt: 'Рыбки — антиутопия о памяти. Обложка проекта.', label: 'Обложка' },
-  { src: '/rybki-assets/02-logline.svg', alt: 'Логлайн полнометражного фильма «Рыбки».', label: 'Логлайн' },
-  { src: '/rybki-assets/03-why-it-hooks.svg', alt: 'Почему история «Рыбки» цепляет зрителя.', label: 'Почему это цепляет' },
-  { src: '/rybki-assets/04-synopsis.svg', alt: 'Синопсис полнометражного фильма «Рыбки».', label: 'Синопсис' },
-  { src: '/rybki-assets/05-main-character.svg', alt: 'Главный герой И-1.', label: 'Главный герой' },
-  { src: '/rybki-assets/06-world.svg', alt: 'Мир и контекст истории «Рыбки».', label: 'Мир' },
-  { src: '/rybki-assets/08-audience.svg', alt: 'Целевая аудитория фильма «Рыбки».', label: 'Для кого' },
-  { src: '/rybki-assets/09-potential.svg', alt: 'Потенциал проекта «Рыбки».', label: 'Потенциал' },
+  { slug: '01-cover', alt: 'Рыбки — антиутопия о памяти. Обложка проекта.', label: 'Обложка' },
+  { slug: '02-logline', alt: 'Логлайн полнометражного фильма «Рыбки».', label: 'Логлайн' },
+  { slug: '03-why-it-hooks', alt: 'Почему история «Рыбки» цепляет зрителя.', label: 'Почему это цепляет' },
+  { slug: '04-synopsis', alt: 'Синопсис полнометражного фильма «Рыбки».', label: 'Синопсис' },
+  { slug: '05-main-character', alt: 'Главный герой И-1.', label: 'Главный герой' },
+  { slug: '06-world', alt: 'Мир и контекст истории «Рыбки».', label: 'Мир' },
+  { slug: '08-audience', alt: 'Целевая аудитория фильма «Рыбки».', label: 'Для кого' },
+  { slug: '09-potential', alt: 'Потенциал проекта «Рыбки».', label: 'Потенциал' },
 ];
 
 function Slide({ slide, index }) {
   const [failed, setFailed] = useState(false);
+  const optimizedBase = `/optimized/rybki-${slide.slug}`;
+  const fallbackSvg = `/rybki-assets/${slide.slug}.svg`;
 
   return (
     <section className="rybki-slide" id={`slide-${index + 1}`}>
@@ -29,16 +31,26 @@ function Slide({ slide, index }) {
         {failed ? (
           <div className="rybki-asset-missing">
             <strong>{slide.label}</strong>
-            <span>SVG-файл не удалось загрузить.</span>
+            <span>Изображение не удалось загрузить.</span>
           </div>
         ) : (
-          <img
-            src={slide.src}
-            alt={slide.alt}
-            loading={index === 0 ? 'eager' : 'lazy'}
-            fetchPriority={index === 0 ? 'high' : 'auto'}
-            onError={() => setFailed(true)}
-          />
+          <picture>
+            <source
+              type="image/webp"
+              srcSet={`${optimizedBase}-640.webp 640w, ${optimizedBase}-1280.webp 1280w, ${optimizedBase}-1920.webp 1920w`}
+              sizes="(max-width: 800px) 94vw, calc(96vw - 174px)"
+            />
+            <img
+              src={fallbackSvg}
+              alt={slide.alt}
+              width="1920"
+              height="1080"
+              loading={index === 0 ? 'eager' : 'lazy'}
+              fetchPriority={index === 0 ? 'high' : 'auto'}
+              decoding={index === 0 ? 'sync' : 'async'}
+              onError={() => setFailed(true)}
+            />
+          </picture>
         )}
       </div>
     </section>
@@ -82,7 +94,7 @@ export default function RybkiPage() {
 
       <div className="rybki-slides">
         {slides.map((slide, index) => (
-          <Slide slide={slide} index={index} key={slide.src} />
+          <Slide slide={slide} index={index} key={slide.slug} />
         ))}
       </div>
 


### PR DESCRIPTION
## Что меняется
- global preload showreel заменён на route-aware preload: главная грузит showreel, `/rybki` — только обложку Рыбок
- восемь тяжёлых SVG-слайдов автоматически рендерятся в responsive WebP 640/1280/1920 при production build
- `/rybki` использует `<picture>` + `srcset` + `sizes`, SVG остаётся fallback
- первый слайд eager/high priority/sync decode; остальные остаются lazy
- добавлены image budgets для обложки Рыбок

## Причина
Исходные SVG весят примерно 2.3–3.6 МБ каждый. Mobile PageSpeed показывает LCP 14.2s на `/rybki`, при этом FCP 1.4s и CLS 0 — узкое место именно доставка LCP-изображения.

## Визуальный риск
Минимальный: WebP генерируются из тех же SVG через Sharp; сохраняются 16:9, исходная композиция и SVG fallback.