### PR TITLE
Match layered Rybki page to source typography

### DIFF
--- a/src/components/RybkiLayeredPage.jsx
+++ b/src/components/RybkiLayeredPage.jsx
@@ -3,10 +3,21 @@ import { Helmet } from 'react-helmet';
 import { ArrowDown, ArrowLeft, MessageCircle } from 'lucide-react';
 import rybkiDeckData from '../generated/rybkiDeckData';
 import './RybkiLayeredPage.css';
+import './RybkiLayeredTypography.css';
 
 const telegramUrl = 'https://t.me/anix_helper';
 
 function cleanCopy(section) {
+  if (section.slug === '02-logline' && section.text?.length) {
+    const story = section.text
+      .slice(1, 8)
+      .join(' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+
+    return [story, 'SCI-FI / ТРИЛЛЕР / САТИРА · РОССИЯ БУДУЩЕГО'];
+  }
+
   const ignored = new Set([
     section.heading.toLowerCase(),
     section.label.toLowerCase(),

--- a/src/components/RybkiLayeredTypography.css
+++ b/src/components/RybkiLayeredTypography.css
@@ -1,0 +1,33 @@
+.rybki-layered-page {
+  font-family: 'Jura', 'Exo 2', 'Raleway', 'Arial Narrow', Arial, sans-serif;
+  font-weight: 300;
+}
+
+.rybki-layered-hero h1,
+.rybki-layered-copy h2,
+.rybki-layered-final h2,
+.rybki-layered-text p:first-child {
+  font-family: 'Jura', 'Exo 2', 'Raleway', 'Arial Narrow', Arial, sans-serif;
+  font-weight: 200;
+  letter-spacing: 0.035em;
+}
+
+.rybki-layered-hero h1,
+.rybki-layered-copy h2,
+.rybki-layered-final h2 {
+  text-transform: uppercase;
+}
+
+.rybki-layered-text p {
+  font-weight: 300;
+  letter-spacing: 0.035em;
+}
+
+.rybki-layered-meta,
+.rybki-layered-title,
+.rybki-layered-back,
+.rybki-layered-contact,
+.rybki-layered-scroll,
+.rybki-layered-final-button {
+  letter-spacing: 0.18em;
+}


### PR DESCRIPTION
## Что меняется
- типографика `/rybki_page` приведена к стеку исходного SVG: Jura / Exo 2 / Raleway / Arial
- крупные заголовки используют тонкий вес и увеличенный letter-spacing вместо Georgia
- точный логлайн, извлечённый из SVG text/tspan, собирается в один читаемый HTML-абзац
- жанр и сеттинг вынесены отдельной строкой

Старый `/rybki` не меняется.