### PR TITLE
Hotfix blank homepage after SEO phase 1

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,12 +7,9 @@ import AppLayout from './AppLayout';
 import RouteBreadcrumbsPortal from './seo/RouteBreadcrumbsPortal';
 import RouteRelatedLinksPortal from './seo/RouteRelatedLinksPortal';
 import SeoHead from './seo/SeoHead';
-import { setupSeoTracking } from './lib/seoTracking';
 
 console.info('[CFG] SUBMIT:', CONFIG.SUBMIT_LEAD_URL);
 console.info('[CFG] TRACK :', CONFIG.TRACK_EVENT_URL);
-
-setupSeoTracking();
 
 const NotFound = lazy(() => import('./components/NotFound'));
 const WhyItWorksPage = lazy(() => import('./components/WhyItWorksPage'));


### PR DESCRIPTION
Emergency production hotfix: remove the new SEO analytics bootstrap from the critical startup path. Static SEO, brand entity changes and corporate contact remain intact. This restores the pre-PR157 React startup sequence while we reintroduce analytics later behind idle/load isolation.