### PR TITLE
Hotfix stale Service Worker and blank-screen fallback

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,8 +1,8 @@
-self.addEventListener('install', (event) => {
+self.addEventListener('install', () => {
   self.skipWaiting();
 });
 
-const cacheName = 'anix-cache-v3';
+const cacheName = 'anix-cache-v4';
 const staticPath = /\/static\//;
 const optimizedPath = /\/optimized\//;
 
@@ -29,29 +29,22 @@ async function cacheFirst(request) {
   return response;
 }
 
-async function networkFirst(request) {
-  const cache = await caches.open(cacheName);
-  try {
-    const response = await fetch(request);
-    if (response && response.status === 200) {
-      const contentType = response.headers.get('content-type') || '';
-      if (/javascript|css|image/.test(contentType)) {
-        cache.put(request, response.clone());
-      }
-    }
-    return response;
-  } catch (error) {
-    const cached = await cache.match(request);
-    return cached || Response.error();
-  }
-}
-
 self.addEventListener('fetch', (event) => {
   if (event.request.method !== 'GET') return;
 
+  // Never let the service worker serve page navigations or HTML documents.
+  // GitHub Pages must always provide the latest route HTML so a stale build
+  // cannot keep referencing an obsolete JavaScript bundle.
+  if (event.request.mode === 'navigate' || event.request.destination === 'document') {
+    return;
+  }
+
   const url = new URL(event.request.url);
   const isSameOrigin = url.origin === self.location.origin;
-  const isStaticAsset = isSameOrigin && (staticPath.test(url.pathname) || optimizedPath.test(url.pathname));
+  const isStaticAsset =
+    isSameOrigin && (staticPath.test(url.pathname) || optimizedPath.test(url.pathname));
 
-  event.respondWith(isStaticAsset ? cacheFirst(event.request) : networkFirst(event.request));
+  if (isStaticAsset) {
+    event.respondWith(cacheFirst(event.request));
+  }
 });

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,6 @@ const RybkiLayeredPage = lazy(() => import('./components/RybkiLayeredPage'));
 const CasePage = lazy(() => import('./components/CasePage'));
 
 const rootElement = document.getElementById('root');
-rootElement.replaceChildren();
 const root = ReactDOM.createRoot(rootElement);
 const base = '';
 const relativePath = window.location.pathname.replace(base, '') || '/';


### PR DESCRIPTION
## Emergency reliability fix

- keep the static SEO shell in the DOM until React successfully renders instead of clearing `#root` before startup completes
- bump the Service Worker cache namespace to `anix-cache-v4`
- stop the Service Worker from intercepting page navigations / HTML documents
- cache only versioned static and optimized assets

This prevents an older Service Worker from keeping stale route HTML that references an obsolete JS bundle, and ensures a runtime error degrades to the readable static SEO shell instead of a blank gray page.