### PR TITLE
Add About Studio section to homepage

### DIFF
--- a/src/components/AboutStudioPortal.css
+++ b/src/components/AboutStudioPortal.css
@@ -1,0 +1,129 @@
+.d1-about-studio {
+  background:
+    radial-gradient(circle at 14% 18%, rgba(19, 203, 178, 0.14), transparent 34%),
+    radial-gradient(circle at 88% 82%, rgba(157, 124, 255, 0.16), transparent 34%),
+    #17131d;
+  color: #fff;
+}
+
+.d1-about-studio-layout {
+  display: grid;
+  grid-template-columns: minmax(360px, 0.85fr) minmax(0, 1.15fr);
+  gap: clamp(48px, 7vw, 120px);
+  align-items: start;
+}
+
+.d1-about-studio-media {
+  position: sticky;
+  top: 112px;
+}
+
+.d1-about-studio-media img {
+  width: 100%;
+  aspect-ratio: 4 / 5;
+  object-fit: cover;
+  object-position: center;
+  border-radius: 36px;
+  box-shadow: 0 34px 80px rgba(0, 0, 0, 0.32);
+}
+
+.d1-about-studio-caption {
+  margin: 16px 0 0;
+  color: rgba(255, 255, 255, 0.58);
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+.d1-about-studio .d1-eyebrow {
+  color: rgba(255, 255, 255, 0.54);
+}
+
+.d1-about-studio h2 {
+  max-width: 920px;
+  color: #fff;
+  font-size: clamp(44px, 5.8vw, 88px);
+  line-height: 0.96;
+}
+
+.d1-about-studio-intro {
+  max-width: 800px;
+  margin: 30px 0 0;
+  color: rgba(255, 255, 255, 0.78);
+  font-size: clamp(19px, 1.8vw, 26px);
+  line-height: 1.45;
+}
+
+.d1-about-studio-pillars {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0;
+  margin-top: 58px;
+  border-top: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.d1-about-studio-pillar {
+  min-width: 0;
+  padding: 30px 32px 34px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.d1-about-studio-pillar:nth-child(odd) {
+  padding-right: 36px;
+  border-right: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.d1-about-studio-pillar:nth-child(even) {
+  padding-left: 36px;
+  padding-right: 0;
+}
+
+.d1-about-studio-pillar h3 {
+  margin: 0;
+  color: #fff;
+  font-size: clamp(21px, 2vw, 30px);
+  line-height: 1.08;
+}
+
+.d1-about-studio-pillar p {
+  margin: 14px 0 0;
+  color: rgba(255, 255, 255, 0.66);
+  font-size: 16px;
+  line-height: 1.62;
+}
+
+@media (max-width: 980px) {
+  .d1-about-studio-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .d1-about-studio-media {
+    position: static;
+    max-width: 720px;
+  }
+
+  .d1-about-studio-media img {
+    aspect-ratio: 16 / 10;
+  }
+}
+
+@media (max-width: 680px) {
+  .d1-about-studio-pillars {
+    grid-template-columns: 1fr;
+  }
+
+  .d1-about-studio-pillar,
+  .d1-about-studio-pillar:nth-child(odd),
+  .d1-about-studio-pillar:nth-child(even) {
+    padding: 26px 0;
+    border-right: 0;
+  }
+
+  .d1-about-studio-media img {
+    aspect-ratio: 4 / 5;
+    border-radius: 26px;
+  }
+
+  .d1-about-studio h2 {
+    font-size: clamp(40px, 12vw, 62px);
+  }
+}

--- a/src/components/AboutStudioPortal.jsx
+++ b/src/components/AboutStudioPortal.jsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import foundersPhoto from '../images/ceo/alexandra-andrey-anix.webp';
+import './AboutStudioPortal.css';
+
+const pillars = [
+  {
+    title: 'Режиссура и драматургия',
+    text: 'Основатели студии Андрей Царёв и Александра Севостьянова сами работают со сценариями и режиссурой. В команде — более 10 лет опыта в драматургии и создании историй.',
+  },
+  {
+    title: 'Наукоёмкий бэкграунд',
+    text: 'В команде есть опыт работы с научными и технологическими темами. Поэтому мы умеем разбираться в сложной фактуре, а не только красиво её оформлять.',
+  },
+  {
+    title: 'AI + классический продакшн',
+    text: 'Anix — полноценная анимационная студия. Мы профессионально используем AI как часть режиссёрского и производственного процесса — вместе с анимацией, дизайном, монтажом и другими инструментами.',
+  },
+  {
+    title: 'От ролика до визуальной системы',
+    text: 'Можем сделать один ролик, а можем развить из него маскота, визуальный язык, серию материалов, презентационные и обучающие форматы.',
+  },
+];
+
+export default function AboutStudioPortal({ path }) {
+  const [mountNode, setMountNode] = useState(null);
+
+  useEffect(() => {
+    if (path !== '/') return undefined;
+
+    let portalNode = null;
+    let observer = null;
+
+    const attach = () => {
+      const finalCta = document.querySelector('.d1-final-cta');
+      if (!finalCta || portalNode) return false;
+
+      portalNode = document.createElement('div');
+      portalNode.dataset.aboutStudioPortal = 'true';
+      finalCta.parentNode.insertBefore(portalNode, finalCta);
+      setMountNode(portalNode);
+      return true;
+    };
+
+    if (!attach()) {
+      observer = new MutationObserver(() => {
+        if (attach() && observer) observer.disconnect();
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+    }
+
+    return () => {
+      if (observer) observer.disconnect();
+      if (portalNode?.parentNode) portalNode.parentNode.removeChild(portalNode);
+    };
+  }, [path]);
+
+  if (path !== '/' || !mountNode) return null;
+
+  return createPortal(
+    <section className="d1-section d1-about-studio" id="about-studio" aria-labelledby="about-studio-title">
+      <div className="d1-container d1-about-studio-layout">
+        <div className="d1-about-studio-media">
+          <img
+            src={foundersPhoto}
+            alt="Основатели Anix Studio Андрей Царёв и Александра Севостьянова"
+            loading="lazy"
+            decoding="async"
+          />
+          <p className="d1-about-studio-caption">Андрей Царёв и Александра Севостьянова — основатели Anix Studio</p>
+        </div>
+
+        <div className="d1-about-studio-copy">
+          <p className="d1-eyebrow">О студии</p>
+          <h2 id="about-studio-title">Собираем сложные темы в истории, которые хочется досмотреть</h2>
+          <p className="d1-about-studio-intro">
+            Anix Studio объединяет режиссуру, драматургию, анимацию и современные AI-инструменты. Мы работаем с продуктами и темами, где одного красивого кадра недостаточно: сначала нужно разобраться, что именно человек должен понять и почувствовать.
+          </p>
+
+          <div className="d1-about-studio-pillars">
+            {pillars.map((pillar) => (
+              <article className="d1-about-studio-pillar" key={pillar.title}>
+                <h3>{pillar.title}</h3>
+                <p>{pillar.text}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>,
+    mountNode,
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom/client';
 import './App.css';
 import App from './App';
 import AppLayout from './AppLayout';
+import AboutStudioPortal from './components/AboutStudioPortal';
 import RouteBreadcrumbsPortal from './seo/RouteBreadcrumbsPortal';
 import RouteRelatedLinksPortal from './seo/RouteRelatedLinksPortal';
 import SeoHead from './seo/SeoHead';
@@ -42,6 +43,7 @@ const renderInLayout = (component) => {
     <AppLayout>
       <SeoHead path={normalizedPath} />
       <Suspense fallback={null}>{component}</Suspense>
+      <AboutStudioPortal path={normalizedPath} />
       <RouteBreadcrumbsPortal path={normalizedPath} />
       <RouteRelatedLinksPortal path={normalizedPath} />
     </AppLayout>,


### PR DESCRIPTION
## About Studio section

Adds a late-page trust section to the homepage, positioned immediately before the final contact CTA.

The section:
- uses the existing founders photo `alexandra-andrey-anix.webp`
- introduces Andrey Tsarev and Alexandra Sevostyanova as founders
- highlights 10+ years of dramaturgy/directing experience
- describes the team’s science-intensive background without over-specific claims
- positions Anix as a full animation studio that professionally uses AI as part of the production process
- explains the studio’s ability to grow one video into a broader visual system

Implementation is isolated in a homepage-only portal component so the existing large landing component and build-time source rewriting remain untouched.

The new production runtime smoke test must pass before merge.