### PR TITLE
Add cases hub and fix footer logo color

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -33,7 +33,18 @@ jobs:
       - name: Production build and SEO verification
         env:
           CI: false
-        run: npm run build
+        shell: bash
+        run: |
+          set -o pipefail
+          npm run build 2>&1 | tee build-output.log
+
+      - name: Upload build diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-output
+          path: build-output.log
+          if-no-files-found: ignore
 
       - name: Runtime smoke test
         run: node scripts/runtime-smoke-test.js

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -33,18 +33,7 @@ jobs:
       - name: Production build and SEO verification
         env:
           CI: false
-        shell: bash
-        run: |
-          set -o pipefail
-          npm run build 2>&1 | tee build-output.log
-
-      - name: Upload build diagnostics
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-output
-          path: build-output.log
-          if-no-files-found: ignore
+        run: npm run build
 
       - name: Runtime smoke test
         run: node scripts/runtime-smoke-test.js

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "node scripts/generate-rybki-page-data.js && node scripts/optimize-assets.js && node scripts/generate-seo-assets.js && node scripts/prepare-seo-source.js && node scripts/build.js",
+    "build": "node scripts/ensure-cases-hub-route.js && node scripts/generate-rybki-page-data.js && node scripts/optimize-assets.js && node scripts/generate-seo-assets.js && node scripts/prepare-seo-source.js && node scripts/build.js",
     "postbuild": "node scripts/create-static-routes.js && node scripts/generate-static-seo.js && node scripts/inject-approved-brand-line.js && node scripts/normalize-seo-output.js && node scripts/verify-seo-build.js",
     "seo:verify": "node scripts/verify-seo-build.js && node scripts/verify-brand-seo.js",
     "optimize:assets": "node scripts/optimize-assets.js",

--- a/scripts/create-static-routes.js
+++ b/scripts/create-static-routes.js
@@ -63,6 +63,7 @@ const routes = [
   'hse',
   'rybki',
   'rybki_page',
+  'cases',
   'cases/clappy',
   'cases/hemotech-ai',
   'cases/tpes',

--- a/scripts/ensure-cases-hub-route.js
+++ b/scripts/ensure-cases-hub-route.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+
+const routesPath = path.resolve(__dirname, '../src/seo/routes.json');
+const config = JSON.parse(fs.readFileSync(routesPath, 'utf8'));
+
+config.routes['/cases'] = {
+  indexable: true,
+  kind: 'webPage',
+  title: 'Кейсы Anix Studio — анимация для B2B, фармы, кино и охраны труда',
+  description:
+    'Кейсы Anix Studio: технологии и B2B, Pharma и MedTech, Cinema & Creative, охрана труда и специальные проекты.',
+  ogTitle: 'Кейсы Anix Studio — сложные продукты в понятных историях',
+  ogDescription:
+    'Проекты Anix для технологий, B2B, фармы, MedTech, кино и охраны труда.',
+  ogImage: '/og/home.jpg',
+  h1: 'Сложные продукты, которые стали понятными историями',
+  intro:
+    'Кейсы Anix Studio для технологий, B2B, фармы, MedTech, кино и охраны труда. Разные задачи и визуальные языки — один принцип: сначала понять, что должно произойти со зрителем.',
+  sections: [
+    {
+      heading: 'Технологии, B2B и сложные продукты',
+      body: 'Объясняющие ролики и визуальные истории для продуктов, которые сложно объяснить одним слайдом.',
+    },
+    {
+      heading: 'Pharma, MedTech и медицина',
+      body: 'Проекты, где одновременно важны точность, доверие, научная логика и внимание аудитории.',
+    },
+    {
+      heading: 'Cinema, Creative и охрана труда',
+      body: 'Кинематографичные эксперименты, исторические миры и визуальные системы для коммуникации правил безопасности.',
+    },
+  ],
+  links: [
+    { label: 'Технологии, B2B и сложные продукты', href: '/cases#b2b' },
+    { label: 'Pharma, MedTech и медицина', href: '/cases#medicine' },
+    { label: 'Cinema & Creative', href: '/cases#cinema' },
+    { label: 'Охрана труда', href: '/cases#hse' },
+    { label: 'Anix Studio', href: '/' },
+  ],
+  breadcrumbs: [
+    { label: 'Главная', href: '/' },
+    { label: 'Кейсы', href: '/cases' },
+  ],
+};
+
+fs.writeFileSync(routesPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+console.log('[seo-routes] ensured /cases hub route');

--- a/scripts/ensure-cases-hub-route.js
+++ b/scripts/ensure-cases-hub-route.js
@@ -9,7 +9,7 @@ config.routes['/cases'] = {
   kind: 'webPage',
   title: 'Кейсы Anix Studio — анимация для B2B, фармы, кино и охраны труда',
   description:
-    'Кейсы Anix Studio: технологии и B2B, Pharma и MedTech, Cinema & Creative, охрана труда и специальные проекты.',
+    'Кейсы Anix Studio: технологии и B2B, Pharma и MedTech, Cinema / Creative, охрана труда и специальные проекты.',
   ogTitle: 'Кейсы Anix Studio — сложные продукты в понятных историях',
   ogDescription:
     'Проекты Anix для технологий, B2B, фармы, MedTech, кино и охраны труда.',

--- a/scripts/runtime-smoke-test.js
+++ b/scripts/runtime-smoke-test.js
@@ -13,6 +13,7 @@ const routes = [
   { path: '/', marker: 'class="design1-test"', extraMarker: 'd1-showreel-poster' },
   { path: '/medicine/', marker: 'class="medicine-page"' },
   { path: '/hse/', marker: 'class="hse-page"' },
+  { path: '/cases/', marker: 'class="cases-hub-page"', extraMarker: 'cases-hub-category' },
 ];
 
 function findChrome() {

--- a/src/components/CasesHubLinkPortal.css
+++ b/src/components/CasesHubLinkPortal.css
@@ -1,0 +1,14 @@
+.d1-cases-hub-link-wrap {
+  display: flex;
+  justify-content: flex-end;
+  margin: 28px 0 0;
+}
+
+.d1-cases-hub-link {
+  width: fit-content;
+}
+
+@media (max-width: 640px) {
+  .d1-cases-hub-link-wrap { justify-content: stretch; }
+  .d1-cases-hub-link { width: 100%; }
+}

--- a/src/components/CasesHubLinkPortal.jsx
+++ b/src/components/CasesHubLinkPortal.jsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { ArrowRight } from 'lucide-react';
+import './CasesHubLinkPortal.css';
+
+export default function CasesHubLinkPortal({ path }) {
+  const [mountNode, setMountNode] = useState(null);
+
+  useEffect(() => {
+    if (path !== '/') return undefined;
+
+    let portalNode = null;
+    let observer = null;
+
+    const attach = () => {
+      const casesHead = document.querySelector('.d1-cases .d1-section-head-row');
+      if (!casesHead || portalNode) return false;
+
+      portalNode = document.createElement('div');
+      portalNode.dataset.casesHubLinkPortal = 'true';
+      casesHead.parentNode.insertBefore(portalNode, casesHead.nextSibling);
+      setMountNode(portalNode);
+      return true;
+    };
+
+    if (!attach()) {
+      observer = new MutationObserver(() => {
+        if (attach() && observer) observer.disconnect();
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+    }
+
+    return () => {
+      if (observer) observer.disconnect();
+      if (portalNode?.parentNode) portalNode.parentNode.removeChild(portalNode);
+    };
+  }, [path]);
+
+  if (path !== '/' || !mountNode) return null;
+
+  return createPortal(
+    <div className="d1-cases-hub-link-wrap">
+      <a className="d1-button d1-button-secondary d1-cases-hub-link" href="/cases/">
+        Смотреть все кейсы
+        <ArrowRight aria-hidden="true" />
+      </a>
+    </div>,
+    mountNode,
+  );
+}

--- a/src/components/CasesHubPage.css
+++ b/src/components/CasesHubPage.css
@@ -1,0 +1,280 @@
+.cases-hub-page {
+  min-height: 100vh;
+  background: #f7f4ef;
+  color: #111;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+.cases-hub-page * { box-sizing: border-box; }
+.cases-hub-page a { color: inherit; text-decoration: none; }
+.cases-hub-page img { display: block; width: 100%; }
+
+.cases-hub-header {
+  position: sticky;
+  top: 16px;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: calc(100% - clamp(32px, 5vw, 96px));
+  margin: 16px auto 0;
+  padding: 10px 12px 10px 18px;
+  border: 1px solid rgba(17, 17, 17, 0.12);
+  border-radius: 999px;
+  background: rgba(255, 250, 242, 0.82);
+  box-shadow: 0 18px 50px rgba(17, 17, 17, 0.08);
+  backdrop-filter: blur(20px);
+}
+
+.cases-hub-logo { width: 92px; }
+.cases-hub-logo img { height: auto; }
+
+.cases-hub-header__cta,
+.cases-hub-cta a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  min-height: 44px;
+  padding: 0 22px;
+  border-radius: 999px;
+  background: #111;
+  color: #fff;
+  font-size: 15px;
+  font-weight: 800;
+}
+
+.cases-hub-hero,
+.cases-hub-category,
+.cases-hub-events,
+.cases-hub-cta {
+  width: min(1440px, calc(100% - clamp(40px, 6vw, 120px)));
+  margin-inline: auto;
+}
+
+.cases-hub-hero {
+  padding: clamp(96px, 12vw, 180px) 0 clamp(88px, 10vw, 150px);
+}
+
+.cases-hub-eyebrow {
+  margin: 0 0 18px;
+  color: rgba(17, 17, 17, 0.5);
+  font-size: 13px;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.cases-hub-hero h1 {
+  max-width: 1180px;
+  margin: 0;
+  font-size: clamp(58px, 9vw, 138px);
+  line-height: 0.9;
+  letter-spacing: -0.055em;
+}
+
+.cases-hub-hero > p:not(.cases-hub-eyebrow) {
+  max-width: 900px;
+  margin: 34px 0 0;
+  color: rgba(17, 17, 17, 0.68);
+  font-size: clamp(20px, 2vw, 30px);
+  line-height: 1.35;
+  font-weight: 620;
+}
+
+.cases-hub-jump {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 42px;
+}
+
+.cases-hub-jump a {
+  padding: 11px 16px;
+  border: 1px solid rgba(17, 17, 17, 0.14);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.54);
+  font-size: 14px;
+  font-weight: 760;
+}
+
+.cases-hub-category {
+  padding: clamp(72px, 9vw, 130px) 0;
+  border-top: 1px solid rgba(17, 17, 17, 0.12);
+}
+
+.cases-hub-category__head {
+  display: grid;
+  grid-template-columns: 86px minmax(0, 900px);
+  gap: clamp(24px, 4vw, 56px);
+  align-items: start;
+  margin-bottom: 48px;
+}
+
+.cases-hub-category__icon,
+.cases-hub-events__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 72px;
+  height: 72px;
+  border-radius: 22px;
+  background: #111;
+  color: #fff;
+}
+
+.cases-hub-category__icon svg,
+.cases-hub-events__icon svg { width: 30px; height: 30px; }
+
+.cases-hub-category h2,
+.cases-hub-events h2,
+.cases-hub-cta h2 {
+  margin: 0;
+  font-size: clamp(42px, 6vw, 86px);
+  line-height: 0.95;
+  letter-spacing: -0.045em;
+}
+
+.cases-hub-category__head > div:last-child > p:last-child {
+  max-width: 840px;
+  margin: 24px 0 0;
+  color: rgba(17, 17, 17, 0.64);
+  font-size: clamp(18px, 1.7vw, 25px);
+  line-height: 1.45;
+}
+
+.cases-hub-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.cases-hub-grid--single { grid-template-columns: minmax(0, 1fr); }
+
+.cases-hub-card {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  overflow: hidden;
+  min-width: 0;
+  border: 1px solid rgba(17, 17, 17, 0.1);
+  border-radius: 34px;
+  background: #fffaf2;
+  box-shadow: 0 20px 54px rgba(17, 17, 17, 0.07);
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+
+a.cases-hub-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 28px 70px rgba(17, 17, 17, 0.12);
+}
+
+.cases-hub-card--featured { grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr); grid-template-rows: 1fr; }
+
+.cases-hub-card__media {
+  overflow: hidden;
+  aspect-ratio: 16 / 9;
+  background: #e8e0ff;
+}
+
+.cases-hub-card__media img {
+  height: 100%;
+  object-fit: cover;
+}
+
+.cases-hub-card__media--placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background:
+    radial-gradient(circle at 30% 30%, rgba(255,255,255,.85), transparent 26%),
+    linear-gradient(135deg, #e7ddff 0%, #c7a9ff 46%, #6c49b8 100%);
+}
+
+.cases-hub-card__media--placeholder span {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 128px;
+  height: 128px;
+  border: 2px solid rgba(255,255,255,.55);
+  border-radius: 34px;
+  color: #fff;
+  font-size: 80px;
+  font-weight: 900;
+  box-shadow: 0 22px 60px rgba(58, 31, 110, .28);
+}
+
+.cases-hub-card__body {
+  display: flex;
+  flex-direction: column;
+  padding: clamp(24px, 3vw, 40px);
+}
+
+.cases-hub-card h3 {
+  margin: 0;
+  font-size: clamp(28px, 3vw, 48px);
+  line-height: 1;
+  letter-spacing: -0.035em;
+}
+
+.cases-hub-card p {
+  margin: 18px 0 28px;
+  color: rgba(17, 17, 17, 0.62);
+  font-size: 17px;
+  line-height: 1.5;
+}
+
+.cases-hub-card__action {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: auto;
+  font-size: 14px;
+  font-weight: 820;
+}
+
+.cases-hub-card__action svg { width: 18px; height: 18px; }
+
+.cases-hub-events {
+  padding: clamp(84px, 10vw, 150px);
+  border-radius: 48px;
+  background: #17131d;
+  color: #fff;
+  text-align: center;
+}
+
+.cases-hub-events__icon { margin: 0 auto 28px; background: #dfff72; color: #17131d; }
+.cases-hub-events .cases-hub-eyebrow { color: rgba(255,255,255,.48); }
+.cases-hub-events p:last-child { max-width: 680px; margin: 24px auto 0; color: rgba(255,255,255,.7); font-size: 20px; line-height: 1.5; }
+
+.cases-hub-cta {
+  padding: clamp(100px, 12vw, 180px) 0;
+}
+
+.cases-hub-cta p:not(.cases-hub-eyebrow) {
+  max-width: 760px;
+  margin: 28px 0 34px;
+  color: rgba(17,17,17,.64);
+  font-size: 21px;
+  line-height: 1.5;
+}
+
+.cases-hub-cta a svg { width: 19px; height: 19px; }
+
+@media (max-width: 900px) {
+  .cases-hub-grid { grid-template-columns: 1fr; }
+  .cases-hub-card--featured { grid-template-columns: 1fr; grid-template-rows: auto 1fr; }
+  .cases-hub-category__head { grid-template-columns: 1fr; }
+  .cases-hub-events { padding-inline: 28px; }
+}
+
+@media (max-width: 640px) {
+  .cases-hub-header { width: calc(100% - 24px); }
+  .cases-hub-header__cta { padding-inline: 16px; font-size: 13px; }
+  .cases-hub-hero,
+  .cases-hub-category,
+  .cases-hub-events,
+  .cases-hub-cta { width: calc(100% - 40px); }
+  .cases-hub-hero h1 { font-size: clamp(52px, 17vw, 82px); }
+  .cases-hub-card { border-radius: 26px; }
+  .cases-hub-category__icon { width: 60px; height: 60px; border-radius: 18px; }
+}

--- a/src/components/CasesHubPage.jsx
+++ b/src/components/CasesHubPage.jsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import { ArrowRight, Film, HeartPulse, HardHat, Sparkles, Workflow } from 'lucide-react';
+import SiteFooter from './SiteFooter';
+import logo from '../images/logoanix.png';
+import agrotechImage from '../images/cases/agrotech.webp';
+import bondarchukImage from '../images/cases/bondarchuk.webp';
+import borodinoImage from '../images/cases/borodino.webp';
+import clappyImage from '../images/cases/clappy.webp';
+import factoryDirectorImage from '../images/cases/factory-director.webp';
+import hemotechImage from '../images/cases/hemotech-ai.webp';
+import koloboxImage from '../images/cases/kolobox.webp';
+import littlePrinceImage from '../images/cases/little-prince.webp';
+import mftiImage from '../images/cases/mfti-endowment.webp';
+import mosfarmaImage from '../images/cases/mosfarma.webp';
+import multonImage from '../images/cases/multon-partners.webp';
+import startechImage from '../images/cases/startech.webp';
+import tpesImage from '../images/cases/tpes.webp';
+import yurrobotImage from '../images/cases/yurrobot.webp';
+import './CasesHubPage.css';
+
+const categories = [
+  {
+    id: 'b2b',
+    eyebrow: 'B2B / Technology',
+    title: 'Технологии, B2B и сложные продукты',
+    description:
+      'Когда продукт сложно объяснить одним слайдом: превращаем механику, пользу и контекст в историю, которую быстрее понимают клиенты, партнёры и инвесторы.',
+    icon: Workflow,
+    cases: [
+      { title: 'Factory Director', image: factoryDirectorImage, note: 'Маскот и конференционный ролик для сложного B2B-продукта.', href: null },
+      { title: 'Стартех', image: startechImage, note: 'Переупаковка продукта и объясняющий ролик для регионального B2B.', href: null },
+      { title: 'Kolobox', image: koloboxImage, note: 'Яркая визуальная история для продукта с непростой первой реакцией аудитории.', href: 'https://drive.google.com/file/d/1eI5mODOu-mJ54QLPM_q0YuUP9bWjLN5k/view' },
+      { title: 'ЮРРОБОТ', image: yurrobotImage, note: 'Короткий ролик для узкой профессиональной аудитории.', href: 'https://drive.google.com/file/d/1bwItNtWXY-IfIrG910jVYGbsOH9BJukR/view' },
+      { title: 'АгроТех', image: agrotechImage, note: 'История, в которой технологичная отрасль становится живым миром будущего.', href: null },
+      { title: 'ТПЭС', image: tpesImage, note: 'Промышленный B2B: объяснить реактивные потери быстрее 50 слайдов.', href: '/cases/tpes/' },
+      { title: 'Эндаумент-фонд МФТИ', image: mftiImage, note: 'Анимационная система, которая стала самостоятельным инфоповодом.', href: '/cases/mfti-endowment/' },
+      { title: 'Clappy', image: clappyImage, note: 'Explainer для продукта, который раньше приходилось долго объяснять.', href: '/cases/clappy/' },
+    ],
+  },
+  {
+    id: 'medicine',
+    eyebrow: 'Pharma / MedTech',
+    title: 'Pharma, MedTech и медицина',
+    description:
+      'Работаем там, где одновременно важны точность, доверие и внимание: медицинские продукты, препараты, научная логика, врачи и пациенты.',
+    icon: HeartPulse,
+    cases: [
+      { title: 'Hemotech AI', image: hemotechImage, note: 'Спокойная визуальная система для инновационного MedTech-продукта.', href: '/cases/hemotech-ai/' },
+      { title: 'Мосфарма', image: mosfarmaImage, note: 'ТВ-ролик с бренд-персонажами и требованиями федерального эфира.', href: '/cases/mosfarma/' },
+      { title: 'Авиандр', image: null, note: 'Медицинская анимация, доказательная база, маскоты и визуальная система препарата.', href: null, placeholder: 'А' },
+    ],
+  },
+  {
+    id: 'cinema',
+    eyebrow: 'Cinema / Creative',
+    title: 'Cinema & Creative',
+    description:
+      'Кинематографичные прототипы, исторические миры и авторские эксперименты — там, где важны атмосфера, художественный язык и скорость проверки идеи.',
+    icon: Film,
+    cases: [
+      { title: 'Маленький принц', image: littlePrinceImage, note: 'Имиджевый ролик-фантазия, собранный за один день.', href: 'https://drive.google.com/file/d/1xIOgHxhhloGtBRtrnwp3xpV9AkShUNqT/view' },
+      { title: 'Фёдор Бондарчук', image: bondarchukImage, note: 'Кинематографичный прототип сцены с нужной атмосферой за несколько часов.', href: 'https://drive.google.com/file/d/1wnRsoYIgio_MilkNFRlEBuTfgJfzx25d/view' },
+      { title: 'Бородино', image: borodinoImage, note: 'Исторический ролик с вниманием к форме, оружию, среде и масштабу.', href: 'https://drive.google.com/file/d/1d2iXB33lqPgG3Y0M4e216nzw2QYGmssP/view' },
+    ],
+  },
+  {
+    id: 'hse',
+    eyebrow: 'HSE / Safety',
+    title: 'Охрана труда',
+    description:
+      'Визуальные системы, которые помогают правилам безопасности не растворяться в регламентах и действительно оставаться в поле внимания сотрудников.',
+    icon: HardHat,
+    cases: [
+      { title: 'Мултон Партнерс', image: multonImage, note: 'Маскот и визуальная система коммуникации жизненно важных правил.', href: '/cases/multon-partners/', featured: true },
+    ],
+  },
+];
+
+function CaseCard({ item }) {
+  const content = (
+    <>
+      <div className={`cases-hub-card__media${item.image ? '' : ' cases-hub-card__media--placeholder'}`}>
+        {item.image ? <img src={item.image} alt={`Кейс Anix: ${item.title}`} loading="lazy" /> : <span>{item.placeholder}</span>}
+      </div>
+      <div className="cases-hub-card__body">
+        <h3>{item.title}</h3>
+        <p>{item.note}</p>
+        <span className="cases-hub-card__action">
+          {item.href ? 'Смотреть кейс' : 'Страница кейса готовится'}
+          {item.href ? <ArrowRight aria-hidden="true" /> : null}
+        </span>
+      </div>
+    </>
+  );
+
+  if (!item.href) return <article className={`cases-hub-card${item.featured ? ' cases-hub-card--featured' : ''}`}>{content}</article>;
+
+  const external = /^https?:\/\//.test(item.href);
+  return (
+    <a
+      className={`cases-hub-card${item.featured ? ' cases-hub-card--featured' : ''}`}
+      href={item.href}
+      target={external ? '_blank' : undefined}
+      rel={external ? 'noreferrer' : undefined}
+    >
+      {content}
+    </a>
+  );
+}
+
+export default function CasesHubPage() {
+  return (
+    <main className="cases-hub-page">
+      <header className="cases-hub-header">
+        <a href="/" className="cases-hub-logo" aria-label="Anix Studio — на главную">
+          <img src={logo} alt="Anix Studio" />
+        </a>
+        <a className="cases-hub-header__cta" href="https://t.me/anix_helper" target="_blank" rel="noreferrer">
+          Обсудить проект
+        </a>
+      </header>
+
+      <section className="cases-hub-hero">
+        <p className="cases-hub-eyebrow">Кейсы Anix Studio</p>
+        <h1>Сложные продукты, которые стали понятными историями</h1>
+        <p>
+          Здесь собраны проекты для технологий, B2B, фармы, MedTech, кино и охраны труда. Разные задачи и визуальные языки — один принцип: сначала понять, что должно произойти со зрителем.
+        </p>
+        <nav className="cases-hub-jump" aria-label="Категории кейсов">
+          {categories.map((category) => (
+            <a href={`#${category.id}`} key={category.id}>{category.title}</a>
+          ))}
+          <a href="#events">Events</a>
+        </nav>
+      </section>
+
+      {categories.map((category) => {
+        const Icon = category.icon;
+        return (
+          <section className="cases-hub-category" id={category.id} key={category.id}>
+            <div className="cases-hub-category__head">
+              <div className="cases-hub-category__icon"><Icon aria-hidden="true" /></div>
+              <div>
+                <p className="cases-hub-eyebrow">{category.eyebrow}</p>
+                <h2>{category.title}</h2>
+                <p>{category.description}</p>
+              </div>
+            </div>
+            <div className={`cases-hub-grid${category.cases.length === 1 ? ' cases-hub-grid--single' : ''}`}>
+              {category.cases.map((item) => <CaseCard item={item} key={item.title} />)}
+            </div>
+          </section>
+        );
+      })}
+
+      <section className="cases-hub-events" id="events">
+        <div className="cases-hub-events__icon"><Sparkles aria-hidden="true" /></div>
+        <p className="cases-hub-eyebrow">Events</p>
+        <h2>Скоро</h2>
+        <p>Добавим проекты с экранным контентом, AI-визуалами и режиссурой событий.</p>
+      </section>
+
+      <section className="cases-hub-cta">
+        <p className="cases-hub-eyebrow">Новая задача</p>
+        <h2>Не нашли кейс ровно из вашей отрасли?</h2>
+        <p>Покажите продукт или идею. Разберёмся в задаче и предложим формат, который имеет смысл именно для неё.</p>
+        <a href="https://t.me/anix_helper" target="_blank" rel="noreferrer">Обсудить проект <ArrowRight aria-hidden="true" /></a>
+      </section>
+
+      <SiteFooter />
+    </main>
+  );
+}

--- a/src/components/CasesHubPage.jsx
+++ b/src/components/CasesHubPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ArrowRight, Film, HeartPulse, HardHat, Sparkles, Workflow } from 'lucide-react';
+import { ArrowRight, Camera, HardHat, Sparkles, Stethoscope, Workflow } from 'lucide-react';
 import SiteFooter from './SiteFooter';
 import logo from '../images/logoanix.png';
 import agrotechImage from '../images/cases/agrotech.webp';
@@ -43,7 +43,7 @@ const categories = [
     title: 'Pharma, MedTech и медицина',
     description:
       'Работаем там, где одновременно важны точность, доверие и внимание: медицинские продукты, препараты, научная логика, врачи и пациенты.',
-    icon: HeartPulse,
+    icon: Stethoscope,
     cases: [
       { title: 'Hemotech AI', image: hemotechImage, note: 'Спокойная визуальная система для инновационного MedTech-продукта.', href: '/cases/hemotech-ai/' },
       { title: 'Мосфарма', image: mosfarmaImage, note: 'ТВ-ролик с бренд-персонажами и требованиями федерального эфира.', href: '/cases/mosfarma/' },
@@ -56,7 +56,7 @@ const categories = [
     title: 'Cinema & Creative',
     description:
       'Кинематографичные прототипы, исторические миры и авторские эксперименты — там, где важны атмосфера, художественный язык и скорость проверки идеи.',
-    icon: Film,
+    icon: Camera,
     cases: [
       { title: 'Маленький принц', image: littlePrinceImage, note: 'Имиджевый ролик-фантазия, собранный за один день.', href: 'https://drive.google.com/file/d/1xIOgHxhhloGtBRtrnwp3xpV9AkShUNqT/view' },
       { title: 'Фёдор Бондарчук', image: bondarchukImage, note: 'Кинематографичный прототип сцены с нужной атмосферой за несколько часов.', href: 'https://drive.google.com/file/d/1wnRsoYIgio_MilkNFRlEBuTfgJfzx25d/view' },

--- a/src/components/SiteFooterLogoFix.css
+++ b/src/components/SiteFooterLogoFix.css
@@ -1,0 +1,4 @@
+/* Keep the footer logo identical to the header logo asset. */
+.anix-site-footer__brand img {
+  filter: none;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import React, { lazy, Suspense } from 'react';
 import { CONFIG } from '@/config';
 import ReactDOM from 'react-dom/client';
 import './App.css';
+import './components/SiteFooterLogoFix.css';
 import App from './App';
 import AppLayout from './AppLayout';
 import AboutStudioPortal from './components/AboutStudioPortal';

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import './App.css';
 import App from './App';
 import AppLayout from './AppLayout';
 import AboutStudioPortal from './components/AboutStudioPortal';
+import CasesHubLinkPortal from './components/CasesHubLinkPortal';
 import RouteBreadcrumbsPortal from './seo/RouteBreadcrumbsPortal';
 import RouteRelatedLinksPortal from './seo/RouteRelatedLinksPortal';
 import SeoHead from './seo/SeoHead';
@@ -23,6 +24,7 @@ const CeoPage = lazy(() => import('./components/CeoPage'));
 const LegalPage = lazy(() => import('./components/LegalPage'));
 const RybkiPage = lazy(() => import('./components/RybkiPage'));
 const RybkiLayeredPage = lazy(() => import('./components/RybkiLayeredPage'));
+const CasesHubPage = lazy(() => import('./components/CasesHubPage'));
 const CasePage = lazy(() => import('./components/CasePage'));
 
 const rootElement = document.getElementById('root');
@@ -44,6 +46,7 @@ const renderInLayout = (component) => {
       <SeoHead path={normalizedPath} />
       <Suspense fallback={null}>{component}</Suspense>
       <AboutStudioPortal path={normalizedPath} />
+      <CasesHubLinkPortal path={normalizedPath} />
       <RouteBreadcrumbsPortal path={normalizedPath} />
       <RouteRelatedLinksPortal path={normalizedPath} />
     </AppLayout>,
@@ -52,6 +55,8 @@ const renderInLayout = (component) => {
 
 if (normalizedPath === '/hse/mvp' || normalizedPath.startsWith('/hse/mvp/')) {
   renderInLayout(<HseMvpPage path={normalizedPath} />);
+} else if (normalizedPath === '/cases') {
+  renderInLayout(<CasesHubPage />);
 } else if (normalizedPath.startsWith('/cases/')) {
   renderInLayout(<CasePage path={normalizedPath} />);
 } else {


### PR DESCRIPTION
## Cases hub + footer logo fix

Adds a new `/cases/` hub page with the agreed thematic structure:
- Технологии, B2B и сложные продукты
- Pharma, MedTech и медицина
- Cinema & Creative
- Охрана труда
- Events teaser: «Скоро»

Also:
- adds a visible «Смотреть все кейсы» link from the homepage cases block
- reuses existing case artwork and links to existing internal case pages where available
- includes an Aviandr placeholder card without inventing artwork
- adds `/cases/` to the SEO/static route build
- adds `/cases/` to the browser runtime smoke test
- removes the footer logo inversion so the footer uses the exact same logo colors as the header

No existing Medicine/HSE copy is changed.