### PR TITLE
Add animation services landing page

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "node scripts/ensure-cases-hub-route.js && node scripts/generate-rybki-page-data.js && node scripts/optimize-assets.js && node scripts/generate-seo-assets.js && node scripts/prepare-seo-source.js && node scripts/build.js",
+    "build": "node scripts/ensure-cases-hub-route.js && node scripts/ensure-animation-route.js && node scripts/generate-rybki-page-data.js && node scripts/optimize-assets.js && node scripts/generate-seo-assets.js && node scripts/prepare-seo-source.js && node scripts/build.js",
     "postbuild": "node scripts/create-static-routes.js && node scripts/generate-static-seo.js && node scripts/inject-approved-brand-line.js && node scripts/normalize-seo-output.js && node scripts/verify-seo-build.js",
     "seo:verify": "node scripts/verify-seo-build.js && node scripts/verify-brand-seo.js",
     "optimize:assets": "node scripts/optimize-assets.js",

--- a/scripts/create-static-routes.js
+++ b/scripts/create-static-routes.js
@@ -31,7 +31,7 @@ const lessonRoutes = [
 ];
 
 const routes = [
-  'medicine','why_it_works','ceo','hse','rybki','rybki_page',
+  'medicine','why_it_works','ceo','hse','animation','rybki','rybki_page',
   'cases','cases/b2b','cases/medicine','cases/cinema','cases/hse',
   'cases/clappy','cases/hemotech-ai','cases/tpes','cases/mfti-endowment','cases/mosfarma','cases/multon-partners',
   'cases/aviandr','cases/little-prince','cases/borodino',

--- a/scripts/ensure-animation-route.js
+++ b/scripts/ensure-animation-route.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+
+const routesPath = path.resolve(__dirname, '../src/seo/routes.json');
+const config = JSON.parse(fs.readFileSync(routesPath, 'utf8'));
+
+config.routes['/animation'] = {
+  indexable: true,
+  kind: 'service',
+  serviceType: 'Создание анимационных роликов',
+  title: 'Создание анимационных роликов для сложных продуктов — Anix Studio',
+  description:
+    'Anix Studio создаёт анимационные ролики для B2B, технологий, фармы, MedTech, обучения и специальных проектов: от сценария и визуального языка до готового ролика.',
+  ogTitle: 'Анимационные ролики для сложных продуктов — Anix Studio',
+  ogDescription:
+    'Объясняющие ролики, продуктовая анимация, научная визуализация, маскоты и mixed media — с режиссурой, драматургией и профессиональным использованием AI.',
+  ogImage: '/og/home.jpg',
+  h1: 'Создание анимационных роликов для сложных продуктов',
+  intro:
+    'Придумываем и производим анимационные ролики для технологий, фармы, B2B, образования и специальных проектов — там, где недостаточно просто красиво показать продукт.',
+  sections: [
+    {
+      heading: 'Объяснить сложное',
+      body: 'Помогаем показать механику продукта, процесс, технологию или идею, которые трудно объяснить одним слайдом или обычной съёмкой.',
+    },
+    {
+      heading: 'Форма под задачу',
+      body: 'Используем объясняющую и продуктовую анимацию, научную визуализацию, персонажей, mixed media, 3D и AI как части одного производственного набора.',
+    },
+    {
+      heading: 'От ролика до визуальной системы',
+      body: 'При необходимости развиваем один ролик в серию, маскота, набор адаптаций, презентационные материалы и другие форматы.',
+    },
+  ],
+  links: [
+    { label: 'Все кейсы Anix Studio', href: '/cases' },
+    { label: 'Маленький принц', href: '/cases/little-prince' },
+    { label: 'Мосфарма', href: '/cases/mosfarma' },
+    { label: 'Авиандр', href: '/cases/aviandr' },
+    { label: 'Мултон Партнерс', href: '/cases/multon-partners' },
+    { label: 'Anix Studio', href: '/' },
+  ],
+  breadcrumbs: [
+    { label: 'Главная', href: '/' },
+    { label: 'Анимационные ролики', href: '/animation' },
+  ],
+};
+
+fs.writeFileSync(routesPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+console.log('[seo-routes] ensured /animation route');

--- a/scripts/runtime-smoke-test.js
+++ b/scripts/runtime-smoke-test.js
@@ -13,6 +13,7 @@ const routes = [
   { path: '/', marker: 'class="design1-test"', extraMarker: 'd1-showreel-poster' },
   { path: '/medicine/', marker: 'class="medicine-page"' },
   { path: '/hse/', marker: 'class="hse-page"' },
+  { path: '/animation/', marker: 'class="animation-page"', extraMarker: 'Создание анимационных роликов для сложных продуктов' },
   { path: '/cases/', marker: 'class="cases-hub-page"', extraMarker: 'cases-hub-category' },
   { path: '/cases/b2b/', marker: 'class="cases-hub-page cases-category-page"', extraMarker: 'Технологии, B2B и сложные продукты' },
   { path: '/cases/medicine/', marker: 'class="cases-hub-page cases-category-page"', extraMarker: 'Pharma, MedTech и медицина' },

--- a/src/components/AnimationPage.css
+++ b/src/components/AnimationPage.css
@@ -1,0 +1,205 @@
+.animation-page {
+  min-height: 100vh;
+  background: #f7f4ef;
+  color: #21162d;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+.animation-page *,
+.animation-page *::before,
+.animation-page *::after { box-sizing: border-box; }
+
+.animation-header {
+  position: sticky;
+  z-index: 30;
+  top: 0;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 28px;
+  width: min(94vw, 1680px);
+  min-height: 76px;
+  margin: 0 auto;
+  border-bottom: 1px solid rgba(33, 22, 45, 0.12);
+  background: rgba(247, 244, 239, 0.9);
+  backdrop-filter: blur(18px);
+}
+
+.animation-header img { display: block; width: auto; height: 34px; }
+.animation-header nav { display: flex; justify-content: center; gap: 24px; }
+.animation-header a { color: inherit; text-decoration: none; }
+.animation-header nav a,
+.animation-header__cta { font-size: 12px; font-weight: 750; letter-spacing: 0.03em; }
+.animation-header__cta { padding: 11px 17px; border-radius: 999px; background: #21162d; color: #fff !important; }
+
+.animation-hero,
+.animation-section,
+.animation-expertise,
+.animation-cta {
+  width: min(94vw, 1680px);
+  margin: 0 auto;
+}
+
+.animation-hero {
+  display: grid;
+  align-content: center;
+  min-height: calc(100vh - 76px);
+  padding: clamp(72px, 9vw, 150px) 0;
+}
+
+.animation-eyebrow {
+  margin: 0;
+  color: #766783;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.animation-hero h1 {
+  max-width: 1320px;
+  margin: 22px 0 0;
+  font-size: clamp(58px, 7.7vw, 142px);
+  font-weight: 760;
+  letter-spacing: -0.064em;
+  line-height: 0.9;
+}
+
+.animation-hero__lead {
+  max-width: 880px;
+  margin: 40px 0 0;
+  color: #554a5f;
+  font-size: clamp(20px, 1.7vw, 30px);
+  line-height: 1.48;
+}
+
+.animation-hero__actions { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 34px; }
+.animation-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  min-height: 52px;
+  padding: 0 21px;
+  border: 1px solid rgba(33, 22, 45, 0.18);
+  border-radius: 999px;
+  color: inherit;
+  font-size: 13px;
+  font-weight: 800;
+  text-decoration: none;
+}
+.animation-button svg { width: 18px; height: 18px; }
+.animation-button--primary { border-color: #21162d; background: #21162d; color: #fff; }
+
+.animation-hero__statement {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  max-width: 880px;
+  margin-top: clamp(70px, 9vw, 150px);
+  padding-top: 24px;
+  border-top: 1px solid rgba(33, 22, 45, 0.16);
+}
+.animation-hero__statement svg { width: 26px; height: 26px; flex: 0 0 auto; }
+.animation-hero__statement p { margin: 0; font-size: clamp(20px, 2vw, 34px); line-height: 1.25; }
+
+.animation-section { padding: clamp(90px, 10vw, 170px) 0; }
+.animation-section--dark {
+  width: 100%;
+  padding-right: max(3vw, calc((100vw - 1680px) / 2));
+  padding-left: max(3vw, calc((100vw - 1680px) / 2));
+  background: #151118;
+  color: #f7f4ef;
+}
+
+.animation-section__heading { display: grid; gap: 18px; max-width: 1040px; margin-bottom: clamp(48px, 6vw, 92px); }
+.animation-section__heading h2 {
+  margin: 0;
+  font-size: clamp(48px, 6vw, 106px);
+  font-weight: 740;
+  letter-spacing: -0.055em;
+  line-height: 0.96;
+}
+.animation-section__heading--with-link { max-width: none; grid-template-columns: 1fr auto; align-items: end; }
+.animation-section__heading--with-link > a { display: inline-flex; align-items: center; gap: 8px; color: inherit; font-weight: 800; text-decoration: none; }
+.animation-section__heading--with-link svg { width: 18px; height: 18px; }
+
+.animation-jobs { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 18px; }
+.animation-jobs article {
+  min-height: 360px;
+  padding: clamp(28px, 3vw, 48px);
+  border: 1px solid rgba(33, 22, 45, 0.16);
+  border-radius: 28px;
+  background: rgba(255,255,255,0.24);
+}
+.animation-jobs svg { width: 32px; height: 32px; }
+.animation-jobs h3 { margin: 100px 0 0; font-size: clamp(28px, 2.4vw, 44px); line-height: 1; }
+.animation-jobs p { margin: 20px 0 0; color: #655a6f; font-size: 17px; line-height: 1.55; }
+
+.animation-formats { border-top: 1px solid rgba(247, 244, 239, 0.16); }
+.animation-formats article {
+  display: grid;
+  grid-template-columns: 90px minmax(0, 1fr);
+  gap: 28px;
+  padding: 34px 0;
+  border-bottom: 1px solid rgba(247, 244, 239, 0.16);
+}
+.animation-formats article > span { color: #928a98; font-size: 12px; letter-spacing: 0.12em; }
+.animation-formats h3 { margin: 0; font-size: clamp(28px, 3.4vw, 62px); letter-spacing: -0.035em; }
+.animation-formats p { max-width: 820px; margin: 12px 0 0; color: #bcb5c1; font-size: 18px; line-height: 1.55; }
+
+.animation-cases { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 24px; }
+.animation-case { overflow: hidden; border: 1px solid rgba(33,22,45,0.13); border-radius: 30px; color: inherit; text-decoration: none; background: rgba(255,255,255,0.22); }
+.animation-case__media { overflow: hidden; aspect-ratio: 16 / 9; background: #21162d; }
+.animation-case__media img { display: block; width: 100%; height: 100%; object-fit: cover; transition: transform 500ms ease; }
+.animation-case:hover .animation-case__media img { transform: scale(1.025); }
+.animation-case__media--placeholder { display: grid; place-items: center; background: radial-gradient(circle at 65% 20%, #9c7dff 0, #49266f 35%, #17111d 100%); }
+.animation-case__media--placeholder span { color: #fff; font-size: clamp(90px, 14vw, 230px); font-weight: 800; }
+.animation-case__body { padding: 26px 28px 30px; }
+.animation-case__body h3 { margin: 0; font-size: clamp(28px, 2.4vw, 44px); }
+.animation-case__body p { margin: 14px 0 26px; color: #655a6f; font-size: 16px; line-height: 1.52; }
+.animation-case__body > span { display: inline-flex; align-items: center; gap: 8px; font-size: 13px; font-weight: 800; }
+.animation-case__body svg { width: 17px; height: 17px; }
+
+.animation-process { border-top: 1px solid rgba(33,22,45,0.14); }
+.animation-process__grid { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); border-top: 1px solid rgba(33,22,45,0.16); }
+.animation-process__grid article { min-height: 310px; padding: 28px 24px; border-right: 1px solid rgba(33,22,45,0.16); }
+.animation-process__grid article:last-child { border-right: 0; }
+.animation-process__grid > article > span { color: #82758d; font-size: 12px; letter-spacing: 0.12em; }
+.animation-process__grid h3 { margin: 80px 0 0; font-size: clamp(24px, 2vw, 36px); }
+.animation-process__grid p { margin: 14px 0 0; color: #655a6f; line-height: 1.52; }
+
+.animation-expertise { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px; padding: 1px; background: rgba(33,22,45,0.13); }
+.animation-expertise > div { display: flex; align-items: center; gap: 16px; min-height: 120px; padding: 24px 30px; background: #f7f4ef; font-size: 18px; font-weight: 750; }
+.animation-expertise svg { width: 28px; height: 28px; }
+
+.animation-cta { padding: clamp(110px, 12vw, 210px) 0; }
+.animation-cta h2 { max-width: 1320px; margin: 22px 0 44px; font-size: clamp(54px, 7vw, 128px); letter-spacing: -0.06em; line-height: 0.92; }
+.animation-cta > a { display: inline-flex; align-items: center; gap: 10px; padding: 16px 22px; border-radius: 999px; background: #21162d; color: #fff; font-weight: 800; text-decoration: none; }
+.animation-cta svg { width: 18px; height: 18px; }
+
+@media (max-width: 980px) {
+  .animation-header { grid-template-columns: auto 1fr; }
+  .animation-header nav { display: none; }
+  .animation-header__cta { justify-self: end; }
+  .animation-jobs,
+  .animation-cases { grid-template-columns: 1fr; }
+  .animation-process__grid { grid-template-columns: 1fr 1fr; }
+  .animation-process__grid article { border-bottom: 1px solid rgba(33,22,45,0.16); }
+  .animation-expertise { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 640px) {
+  .animation-header { width: 92vw; gap: 12px; min-height: 68px; }
+  .animation-header__cta { padding: 10px 13px; font-size: 11px; }
+  .animation-hero,
+  .animation-section,
+  .animation-expertise,
+  .animation-cta { width: 92vw; }
+  .animation-section--dark { width: 100%; padding-right: 4vw; padding-left: 4vw; }
+  .animation-hero h1 { font-size: clamp(52px, 15vw, 82px); }
+  .animation-section__heading--with-link { grid-template-columns: 1fr; }
+  .animation-formats article { grid-template-columns: 48px 1fr; gap: 14px; }
+  .animation-process__grid { grid-template-columns: 1fr; }
+  .animation-process__grid article { min-height: 240px; border-right: 0; }
+}

--- a/src/components/AnimationPage.jsx
+++ b/src/components/AnimationPage.jsx
@@ -1,0 +1,209 @@
+import React from 'react';
+import { ArrowRight, Film, Layers3, MessageCircle, Microscope, Sparkles, WandSparkles } from 'lucide-react';
+import BrandLogo from './BrandLogo';
+import SiteFooter from './SiteFooter';
+import littlePrinceImage from '../images/cases/little-prince.webp';
+import agrotechImage from '../images/cases/agrotech.webp';
+import multonImage from '../images/cases/multon-partners.webp';
+import mosfarmaImage from '../images/cases/mosfarma.webp';
+import hemotechImage from '../images/cases/hemotech-ai.webp';
+import './AnimationPage.css';
+
+const telegramUrl = 'https://t.me/anix_helper';
+
+const jobs = [
+  {
+    icon: Layers3,
+    title: 'Объяснить сложное',
+    text: 'Когда продукт, технология или процесс не помещаются в один слайд, а обычная съёмка не показывает главное.',
+  },
+  {
+    icon: Sparkles,
+    title: 'Сделать так, чтобы запомнили',
+    text: 'Создаём визуальный язык, персонажей и сцены, которые продолжают жить после первого просмотра.',
+  },
+  {
+    icon: Film,
+    title: 'Показать то, что нельзя снять',
+    text: 'Молекулы, исторические миры, будущие технологии, внутренние процессы и невозможные пространства.',
+  },
+];
+
+const formats = [
+  ['Объясняющие ролики', 'Для B2B, технологий и продуктов с длинным циклом принятия решения.'],
+  ['Продуктовая анимация', 'Когда нужно показать механику, интерфейс, процесс или ценность продукта.'],
+  ['Научная визуализация', 'Для медицины, фармы, MedTech и других наукоёмких тем.'],
+  ['Персонажи и маскоты', 'Создаём героев, которые удерживают внимание и собирают вокруг продукта узнаваемый язык.'],
+  ['Cinematic & mixed media', 'Соединяем анимацию, AI, графику, 3D и другие техники под конкретную режиссёрскую задачу.'],
+  ['Серии и визуальные системы', 'Один ролик может стать началом системы: адаптаций, карточек, презентаций и следующих выпусков.'],
+];
+
+const cases = [
+  {
+    title: 'Маленький принц',
+    note: 'Кинематографичная фантазия и проверка художественного языка в очень короткий срок.',
+    image: littlePrinceImage,
+    href: '/cases/little-prince/',
+  },
+  {
+    title: 'АгроТех',
+    note: 'Технологичная отрасль превращается в живой мир будущего — вместо сухого рассказа о продукте.',
+    image: agrotechImage,
+    href: '/cases/b2b/',
+  },
+  {
+    title: 'Мултон Партнерс',
+    note: 'Маскот и визуальная система, которая помогает правилам безопасности оставаться в поле внимания.',
+    image: multonImage,
+    href: '/cases/multon-partners/',
+  },
+  {
+    title: 'Мосфарма',
+    note: 'Анимационный ролик с бренд-персонажами, подготовленный под требования федерального эфира.',
+    image: mosfarmaImage,
+    href: '/cases/mosfarma/',
+  },
+  {
+    title: 'Авиандр',
+    note: 'Медицинская анимация, маскоты и визуальный язык для врачебной аудитории.',
+    placeholder: 'А',
+    href: '/cases/aviandr/',
+  },
+  {
+    title: 'Hemotech AI',
+    note: 'Минималистичная визуальная система для сложного MedTech-продукта.',
+    image: hemotechImage,
+    href: '/cases/hemotech-ai/',
+  },
+];
+
+const process = [
+  ['01', 'Разбираемся', 'Понимаем продукт, аудиторию, контекст просмотра и то, что зритель должен унести с собой.'],
+  ['02', 'Строим историю', 'Находим драматургию, визуальную метафору и форму, которая работает именно для этой задачи.'],
+  ['03', 'Создаём язык', 'Определяем стиль, персонажей, композицию, движение и производственный пайплайн.'],
+  ['04', 'Производим', 'Соединяем анимацию, дизайн, AI, 3D, монтаж и звук в нужной пропорции.'],
+  ['05', 'Развиваем', 'При необходимости превращаем ролик в серию, визуальную систему или набор адаптаций.'],
+];
+
+function CaseCard({ item }) {
+  return (
+    <a className="animation-case" href={item.href}>
+      <div className={`animation-case__media${item.image ? '' : ' animation-case__media--placeholder'}`}>
+        {item.image ? <img src={item.image} alt={`Кейс Anix: ${item.title}`} loading="lazy" /> : <span>{item.placeholder}</span>}
+      </div>
+      <div className="animation-case__body">
+        <h3>{item.title}</h3>
+        <p>{item.note}</p>
+        <span>Смотреть кейс <ArrowRight aria-hidden="true" /></span>
+      </div>
+    </a>
+  );
+}
+
+export default function AnimationPage() {
+  return (
+    <main className="animation-page">
+      <header className="animation-header">
+        <a href="/" aria-label="Anix Studio — на главную"><BrandLogo alt="Anix Studio" width={120} height={44} /></a>
+        <nav aria-label="Навигация страницы анимационных роликов">
+          <a href="#tasks">Задачи</a>
+          <a href="#formats">Форматы</a>
+          <a href="#cases">Кейсы</a>
+        </nav>
+        <a className="animation-header__cta" href={telegramUrl} target="_blank" rel="noreferrer">Обсудить ролик</a>
+      </header>
+
+      <section className="animation-hero">
+        <p className="animation-eyebrow">Anix Studio / анимационные ролики</p>
+        <h1>Создание анимационных роликов для сложных продуктов</h1>
+        <p className="animation-hero__lead">
+          Придумываем и производим анимационные ролики для технологий, фармы, B2B, образования и специальных проектов — там, где недостаточно просто красиво показать продукт.
+        </p>
+        <div className="animation-hero__actions">
+          <a className="animation-button animation-button--primary" href={telegramUrl} target="_blank" rel="noreferrer">
+            <MessageCircle aria-hidden="true" /> Обсудить задачу
+          </a>
+          <a className="animation-button" href="/cases/">Посмотреть кейсы <ArrowRight aria-hidden="true" /></a>
+        </div>
+        <div className="animation-hero__statement">
+          <WandSparkles aria-hidden="true" />
+          <p>Не начинаем с вопроса «2D или 3D?». Сначала понимаем, что должно произойти со зрителем.</p>
+        </div>
+      </section>
+
+      <section className="animation-section" id="tasks">
+        <div className="animation-section__heading">
+          <p className="animation-eyebrow">Когда нужна анимация</p>
+          <h2>Когда продукт нельзя нормально объяснить обычным кадром</h2>
+        </div>
+        <div className="animation-jobs">
+          {jobs.map(({ icon: Icon, title, text }) => (
+            <article key={title}>
+              <Icon aria-hidden="true" />
+              <h3>{title}</h3>
+              <p>{text}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="animation-section animation-section--dark" id="formats">
+        <div className="animation-section__heading">
+          <p className="animation-eyebrow">Что создаём</p>
+          <h2>Форма под задачу, а не задача под технику</h2>
+        </div>
+        <div className="animation-formats">
+          {formats.map(([title, text], index) => (
+            <article key={title}>
+              <span>{String(index + 1).padStart(2, '0')}</span>
+              <div><h3>{title}</h3><p>{text}</p></div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="animation-section" id="cases">
+        <div className="animation-section__heading animation-section__heading--with-link">
+          <div>
+            <p className="animation-eyebrow">Работы Anix</p>
+            <h2>Разные задачи. Разные визуальные языки.</h2>
+          </div>
+          <a href="/cases/">Все кейсы <ArrowRight aria-hidden="true" /></a>
+        </div>
+        <div className="animation-cases">
+          {cases.map((item) => <CaseCard item={item} key={item.title} />)}
+        </div>
+      </section>
+
+      <section className="animation-section animation-process">
+        <div className="animation-section__heading">
+          <p className="animation-eyebrow">Как работаем</p>
+          <h2>От сложной фактуры до ролика, который хочется досмотреть</h2>
+        </div>
+        <div className="animation-process__grid">
+          {process.map(([number, title, text]) => (
+            <article key={number}>
+              <span>{number}</span>
+              <h3>{title}</h3>
+              <p>{text}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="animation-expertise">
+        <div><Microscope aria-hidden="true" /><span>Наукоёмкий бэкграунд</span></div>
+        <div><Film aria-hidden="true" /><span>Режиссура и драматургия</span></div>
+        <div><WandSparkles aria-hidden="true" /><span>AI как часть продакшна</span></div>
+      </section>
+
+      <section className="animation-cta">
+        <p className="animation-eyebrow">Есть сложная задача?</p>
+        <h2>Покажите продукт. Придумаем, как сделать его понятным и интересным.</h2>
+        <a href={telegramUrl} target="_blank" rel="noreferrer">Обсудить анимационный ролик <ArrowRight aria-hidden="true" /></a>
+      </section>
+
+      <SiteFooter />
+    </main>
+  );
+}

--- a/src/components/SiteFooter.jsx
+++ b/src/components/SiteFooter.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   ArrowRight,
   ExternalLink,
+  Film,
   HardHat,
   Mail,
   MessageCircle,
@@ -20,6 +21,7 @@ const videoFolderUrl =
 
 const pageLinks = [
   { label: 'Главная', href: '/' },
+  { label: 'Анимационные ролики', href: '/animation' },
   { label: 'Кейсы', href: '/cases' },
   { label: 'Medicine', href: '/medicine' },
   { label: 'HSE', href: '/hse' },
@@ -34,6 +36,11 @@ const pageLinks = [
 ];
 
 const directionLinks = [
+  {
+    label: 'Анимационные ролики',
+    href: '/animation',
+    icon: Film,
+  },
   {
     label: 'Фарма и MedTech',
     href: '/medicine',
@@ -126,6 +133,9 @@ export default function SiteFooter() {
 
       <div className="anix-site-footer__bottom">
         <span>Anix Studio</span>
+        <a href={toPublicHref('/animation')}>
+          Анимационные ролики <ArrowRight aria-hidden="true" />
+        </a>
         <a href={toPublicHref('/medicine')}>
           Medicine <ArrowRight aria-hidden="true" />
         </a>

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ const NotFound = lazy(() => import('./components/NotFound'));
 const WhyItWorksPage = lazy(() => import('./components/WhyItWorksPage'));
 const MedicinePage = lazy(() => import('./components/MedicinePage'));
 const HsePage = lazy(() => import('./components/HsePage'));
+const AnimationPage = lazy(() => import('./components/AnimationPage'));
 const HseMvpPage = lazy(() => import('./features/hseMvp/HseMvpPage'));
 const Design1TestPage = lazy(() => import('./components/Design1TestPage'));
 const DesignOldPage = lazy(() => import('./components/DesignOldPage'));
@@ -76,6 +77,9 @@ if (normalizedPath === '/hse/mvp' || normalizedPath.startsWith('/hse/mvp/')) {
       break;
     case '/hse':
       renderInLayout(<HsePage />);
+      break;
+    case '/animation':
+      renderInLayout(<AnimationPage />);
       break;
     case '/rybki':
     case '/rybki_page':


### PR DESCRIPTION
Adds a new commercial landing page at `/animation/` for animation production services.

Includes:
- hero and positioning for creating animated videos for complex products
- business-task-oriented sections instead of a technique catalog
- formats: explainer, product animation, scientific visualization, mascots, mixed media, visual systems
- featured cases: Little Prince, Agrotech, Multon Partners, Mosfarma, Aviandr, Hemotech AI
- production process and expertise blocks
- internal links to cases and Telegram CTA
- SEO metadata, Service schema route config, breadcrumbs and static GitHub Pages route
- footer links under “Анимационные ролики”
- runtime smoke-test coverage for `/animation/`

Existing Medicine and HSE landing copy is not changed.