### PR TITLE
Add AI video services landing page

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "node scripts/ensure-cases-hub-route.js && node scripts/ensure-animation-route.js && node scripts/generate-rybki-page-data.js && node scripts/optimize-assets.js && node scripts/generate-seo-assets.js && node scripts/prepare-seo-source.js && node scripts/build.js",
+    "build": "node scripts/ensure-cases-hub-route.js && node scripts/ensure-animation-route.js && node scripts/ensure-ai-video-route.js && node scripts/generate-rybki-page-data.js && node scripts/optimize-assets.js && node scripts/generate-seo-assets.js && node scripts/prepare-seo-source.js && node scripts/build.js",
     "postbuild": "node scripts/create-static-routes.js && node scripts/generate-static-seo.js && node scripts/inject-approved-brand-line.js && node scripts/normalize-seo-output.js && node scripts/verify-seo-build.js",
     "seo:verify": "node scripts/verify-seo-build.js && node scripts/verify-brand-seo.js",
     "optimize:assets": "node scripts/optimize-assets.js",

--- a/scripts/create-static-routes.js
+++ b/scripts/create-static-routes.js
@@ -31,7 +31,7 @@ const lessonRoutes = [
 ];
 
 const routes = [
-  'medicine','why_it_works','ceo','hse','animation','rybki','rybki_page',
+  'medicine','why_it_works','ceo','hse','animation','ai-video','rybki','rybki_page',
   'cases','cases/b2b','cases/medicine','cases/cinema','cases/hse',
   'cases/clappy','cases/hemotech-ai','cases/tpes','cases/mfti-endowment','cases/mosfarma','cases/multon-partners',
   'cases/aviandr','cases/little-prince','cases/borodino',

--- a/scripts/ensure-ai-video-route.js
+++ b/scripts/ensure-ai-video-route.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+
+const routesPath = path.resolve(__dirname, '../src/seo/routes.json');
+const config = JSON.parse(fs.readFileSync(routesPath, 'utf8'));
+
+config.routes['/ai-video'] = {
+  indexable: true,
+  kind: 'service',
+  serviceType: 'AI-видео и генеративный видеопродакшн',
+  title: 'AI-видео для бизнеса и сложных визуальных задач — Anix Studio',
+  description:
+    'Anix Studio профессионально использует AI внутри полноценного анимационного продакшна: сценарий, режиссура, арт-дирекшен, генеративное видео, анимация и постпродакшн.',
+  ogTitle: 'AI-видео с режиссурой и полноценным продакшном — Anix Studio',
+  ogDescription:
+    'Не AI ради AI: генеративное видео как часть режиссёрского, анимационного и постпродакшн-пайплайна.',
+  ogImage: '/og/home.jpg',
+  h1: 'AI-видео с режиссурой, продакшном и вкусом',
+  intro:
+    'Anix — полноценная анимационная студия, которая профессионально использует AI внутри продакшна и соединяет генеративные инструменты со сценарием, арт-дирекшеном, анимацией и постпродакшном.',
+  sections: [
+    {
+      heading: 'Что AI действительно даёт',
+      body: 'Помогает показывать невозможные миры и будущие продукты, быстрее проверять визуальные идеи и собирать гибридные производственные пайплайны.',
+    },
+    {
+      heading: 'Не AI ради AI',
+      body: 'Если задачу надёжнее решить съёмкой, 3D или классической анимацией, используем подходящий инструмент. AI не заменяет режиссуру и художественные решения.',
+    },
+    {
+      heading: 'Контроль качества',
+      body: 'Работаем с консистентностью персонажей и продукта, монтажом, композингом, ручной доработкой и другими этапами, которые превращают генерации в законченный ролик.',
+    },
+  ],
+  links: [
+    { label: 'Анимационные ролики', href: '/animation' },
+    { label: 'Все кейсы Anix Studio', href: '/cases' },
+    { label: 'Маленький принц', href: '/cases/little-prince' },
+    { label: 'Бородино', href: '/cases/borodino' },
+    { label: 'Cinema & Creative', href: '/cases/cinema' },
+    { label: 'Anix Studio', href: '/' },
+  ],
+  breadcrumbs: [
+    { label: 'Главная', href: '/' },
+    { label: 'AI-видео', href: '/ai-video' },
+  ],
+};
+
+fs.writeFileSync(routesPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+console.log('[seo-routes] ensured /ai-video route');

--- a/scripts/runtime-smoke-test.js
+++ b/scripts/runtime-smoke-test.js
@@ -14,6 +14,7 @@ const routes = [
   { path: '/medicine/', marker: 'class="medicine-page"' },
   { path: '/hse/', marker: 'class="hse-page"' },
   { path: '/animation/', marker: 'class="animation-page"', extraMarker: 'Создание анимационных роликов для сложных продуктов' },
+  { path: '/ai-video/', marker: 'class="ai-video-page"', extraMarker: 'AI-видео с режиссурой, продакшном и вкусом' },
   { path: '/cases/', marker: 'class="cases-hub-page"', extraMarker: 'cases-hub-category' },
   { path: '/cases/b2b/', marker: 'class="cases-hub-page cases-category-page"', extraMarker: 'Технологии, B2B и сложные продукты' },
   { path: '/cases/medicine/', marker: 'class="cases-hub-page cases-category-page"', extraMarker: 'Pharma, MedTech и медицина' },

--- a/src/components/AiVideoPage.css
+++ b/src/components/AiVideoPage.css
@@ -1,0 +1,393 @@
+.ai-video-page {
+  min-height: 100vh;
+  background: #f5f0f7;
+  color: #21162d;
+}
+
+.ai-video-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 28px;
+  width: min(94vw, 1680px);
+  margin: 0 auto;
+  padding: 18px 0;
+  background: rgba(245, 240, 247, 0.88);
+  backdrop-filter: blur(18px);
+}
+
+.ai-video-header nav {
+  display: flex;
+  justify-content: center;
+  gap: 28px;
+}
+
+.ai-video-header a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.ai-video-header nav a {
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.ai-video-header__cta,
+.ai-video-button,
+.ai-video-cta a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  min-height: 48px;
+  padding: 0 20px;
+  border: 1px solid rgba(33, 22, 45, 0.18);
+  border-radius: 999px;
+  color: #21162d;
+  font-size: 13px;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.ai-video-header__cta,
+.ai-video-button--primary,
+.ai-video-cta a {
+  border-color: #21162d;
+  background: #21162d;
+  color: #fff;
+}
+
+.ai-video-hero,
+.ai-video-section,
+.ai-video-cta {
+  width: min(94vw, 1680px);
+  margin: 0 auto;
+}
+
+.ai-video-hero {
+  display: grid;
+  align-content: center;
+  min-height: calc(100vh - 80px);
+  padding: clamp(72px, 8vw, 140px) 0;
+}
+
+.ai-video-eyebrow {
+  margin: 0;
+  color: #6d5b7e;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.ai-video-hero h1,
+.ai-video-section__heading h2,
+.ai-video-cta h2 {
+  letter-spacing: -0.055em;
+}
+
+.ai-video-hero h1 {
+  max-width: 1180px;
+  margin: 18px 0 0;
+  font-size: clamp(58px, 8vw, 142px);
+  line-height: 0.9;
+}
+
+.ai-video-hero__lead {
+  max-width: 900px;
+  margin: 34px 0 0;
+  color: #554a5f;
+  font-size: clamp(20px, 1.8vw, 30px);
+  line-height: 1.48;
+}
+
+.ai-video-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 34px;
+}
+
+.ai-video-button svg,
+.ai-video-cta a svg,
+.ai-video-case__body span svg,
+.ai-video-section__heading--with-link > a svg {
+  width: 18px;
+  height: 18px;
+}
+
+.ai-video-hero__statement {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 18px;
+  max-width: 900px;
+  margin-top: clamp(56px, 7vw, 110px);
+  padding-top: 28px;
+  border-top: 1px solid rgba(33, 22, 45, 0.14);
+}
+
+.ai-video-hero__statement svg {
+  width: 28px;
+  height: 28px;
+}
+
+.ai-video-hero__statement p {
+  margin: 0;
+  font-size: clamp(19px, 1.6vw, 27px);
+  line-height: 1.45;
+}
+
+.ai-video-section {
+  padding: clamp(88px, 10vw, 180px) 0;
+}
+
+.ai-video-section--dark {
+  width: 100%;
+  padding-right: max(3vw, calc((100vw - 1680px) / 2));
+  padding-left: max(3vw, calc((100vw - 1680px) / 2));
+  background: #21162d;
+  color: #fff;
+}
+
+.ai-video-section--dark .ai-video-eyebrow,
+.ai-video-section--dark .ai-video-principles article > span {
+  color: #c4a8dc;
+}
+
+.ai-video-section__heading {
+  max-width: 1050px;
+  margin-bottom: clamp(48px, 6vw, 94px);
+}
+
+.ai-video-section__heading h2,
+.ai-video-cta h2 {
+  margin: 14px 0 0;
+  font-size: clamp(44px, 5.8vw, 104px);
+  line-height: 0.95;
+}
+
+.ai-video-section__heading--with-link {
+  display: flex;
+  max-width: none;
+  align-items: end;
+  justify-content: space-between;
+  gap: 32px;
+}
+
+.ai-video-section__heading--with-link > div {
+  max-width: 1050px;
+}
+
+.ai-video-section__heading--with-link > a {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: inherit;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.ai-video-capabilities,
+.ai-video-control__grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.ai-video-capabilities article,
+.ai-video-control__grid > div {
+  min-height: 330px;
+  padding: 34px;
+  border: 1px solid rgba(33, 22, 45, 0.14);
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.44);
+}
+
+.ai-video-capabilities svg,
+.ai-video-control__grid svg {
+  width: 34px;
+  height: 34px;
+}
+
+.ai-video-capabilities h3,
+.ai-video-control__grid h3,
+.ai-video-principles h3,
+.ai-video-process__grid h3,
+.ai-video-case__body h3 {
+  margin: 28px 0 0;
+  font-size: clamp(24px, 2vw, 36px);
+  line-height: 1.05;
+}
+
+.ai-video-capabilities p,
+.ai-video-control__grid p,
+.ai-video-principles p,
+.ai-video-process__grid p,
+.ai-video-case__body p {
+  margin: 16px 0 0;
+  color: #62566b;
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+.ai-video-principles {
+  border-top: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.ai-video-principles article {
+  display: grid;
+  grid-template-columns: 80px minmax(0, 1fr);
+  gap: 24px;
+  padding: 34px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.ai-video-principles article > span,
+.ai-video-process__grid article > span {
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+}
+
+.ai-video-principles h3 {
+  margin-top: 0;
+}
+
+.ai-video-principles p {
+  max-width: 900px;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.ai-video-cases {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 22px;
+}
+
+.ai-video-case {
+  overflow: hidden;
+  border: 1px solid rgba(33, 22, 45, 0.12);
+  border-radius: 30px;
+  background: rgba(255, 255, 255, 0.48);
+  color: inherit;
+  text-decoration: none;
+}
+
+.ai-video-case__media {
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  background: #ddd3e3;
+}
+
+.ai-video-case__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.45s ease;
+}
+
+.ai-video-case:hover .ai-video-case__media img {
+  transform: scale(1.025);
+}
+
+.ai-video-case__body {
+  padding: 28px;
+}
+
+.ai-video-case__body h3 {
+  margin-top: 0;
+}
+
+.ai-video-case__body span {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 24px;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.ai-video-control {
+  border-top: 1px solid rgba(33, 22, 45, 0.12);
+}
+
+.ai-video-process__grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.ai-video-process__grid article {
+  min-height: 300px;
+  padding: 28px;
+  border-top: 1px solid rgba(33, 22, 45, 0.18);
+}
+
+.ai-video-process__grid h3 {
+  margin-top: 34px;
+}
+
+.ai-video-cta {
+  padding: clamp(90px, 12vw, 220px) 0;
+  text-align: center;
+}
+
+.ai-video-cta h2 {
+  max-width: 1280px;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.ai-video-cta a {
+  margin-top: 36px;
+}
+
+@media (max-width: 980px) {
+  .ai-video-header {
+    grid-template-columns: 1fr auto;
+  }
+
+  .ai-video-header nav {
+    display: none;
+  }
+
+  .ai-video-capabilities,
+  .ai-video-control__grid,
+  .ai-video-process__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .ai-video-cases {
+    grid-template-columns: 1fr;
+  }
+
+  .ai-video-section__heading--with-link {
+    display: grid;
+  }
+}
+
+@media (max-width: 640px) {
+  .ai-video-header__cta {
+    min-height: 42px;
+    padding: 0 14px;
+  }
+
+  .ai-video-hero h1 {
+    font-size: clamp(48px, 16vw, 78px);
+  }
+
+  .ai-video-hero__lead {
+    font-size: 19px;
+  }
+
+  .ai-video-hero__actions {
+    display: grid;
+  }
+
+  .ai-video-principles article {
+    grid-template-columns: 44px minmax(0, 1fr);
+  }
+}

--- a/src/components/AiVideoPage.jsx
+++ b/src/components/AiVideoPage.jsx
@@ -1,0 +1,217 @@
+import React from 'react';
+import {
+  ArrowRight,
+  Clapperboard,
+  Eye,
+  Film,
+  Layers3,
+  MessageCircle,
+  ShieldCheck,
+  Sparkles,
+  WandSparkles,
+} from 'lucide-react';
+import BrandLogo from './BrandLogo';
+import SiteFooter from './SiteFooter';
+import littlePrinceImage from '../images/cases/little-prince.webp';
+import bondarchukImage from '../images/cases/bondarchuk.webp';
+import borodinoImage from '../images/cases/borodino.webp';
+import agrotechImage from '../images/cases/agrotech.webp';
+import hemotechImage from '../images/cases/hemotech-ai.webp';
+import './AiVideoPage.css';
+
+const telegramUrl = 'https://t.me/anix_helper';
+
+const capabilities = [
+  {
+    icon: Eye,
+    title: 'Показать то, чего ещё нет',
+    text: 'Будущие продукты, невозможные миры, исторические сцены и визуальные метафоры без тяжёлой съёмочной инфраструктуры.',
+  },
+  {
+    icon: WandSparkles,
+    title: 'Быстрее проверять идеи',
+    text: 'Можно раньше увидеть художественное направление, протестировать образ сцены и понять, куда действительно стоит вкладывать продакшн.',
+  },
+  {
+    icon: Layers3,
+    title: 'Собирать гибридный пайплайн',
+    text: 'Соединяем AI с анимацией, графикой, 3D, монтажом, композингом и ручной доработкой — в нужной пропорции.',
+  },
+];
+
+const principles = [
+  ['AI не заменяет режиссуру', 'Модель может сгенерировать кадр, но не определяет драматургию, темп, точку зрения и то, зачем зрителю смотреть дальше.'],
+  ['Не используем AI ради AI', 'Если задачу надёжнее решить съёмкой, 3D или классической анимацией, выбираем подходящий инструмент, а не модный ярлык.'],
+  ['Контролируем консистентность', 'Персонажи, продукт, композиция и стиль требуют системы: референсов, отбора, итераций, композинга и ручной доработки.'],
+  ['Собираем результат, а не набор генераций', 'Клиенту нужен законченный ролик с понятной задачей, а не папка красивых экспериментов.'],
+];
+
+const cases = [
+  {
+    title: 'Маленький принц',
+    note: 'Кинематографичная фантазия и быстрый поиск художественного языка с помощью генеративного продакшна.',
+    image: littlePrinceImage,
+    href: '/cases/little-prince/',
+  },
+  {
+    title: 'Фёдор Бондарчук',
+    note: 'Прототип кинематографичной сцены с нужной атмосферой за несколько часов вместо длинного предпродакшна.',
+    image: bondarchukImage,
+    href: '/cases/cinema/',
+  },
+  {
+    title: 'Бородино',
+    note: 'Исторический мир, масштаб и атмосфера с вниманием к форме, оружию и среде.',
+    image: borodinoImage,
+    href: '/cases/borodino/',
+  },
+  {
+    title: 'АгроТех',
+    note: 'Технологичная отрасль превращается в визуальный мир будущего вместо сухого продуктового рассказа.',
+    image: agrotechImage,
+    href: '/cases/b2b/',
+  },
+  {
+    title: 'Hemotech AI',
+    note: 'Пример того, как технологичный продукт можно показывать без визуального AI-пафоса и клише.',
+    image: hemotechImage,
+    href: '/cases/hemotech-ai/',
+  },
+];
+
+const process = [
+  ['01', 'Задача и сценарий', 'Определяем, что нужно объяснить, почувствовать или запомнить — до выбора моделей и инструментов.'],
+  ['02', 'Визуальная система', 'Собираем референсы, правила мира, персонажей, композицию и критерии консистентности.'],
+  ['03', 'Генерация и производство', 'Используем подходящие AI-модели вместе с анимацией, 3D, монтажом и другими инструментами.'],
+  ['04', 'Отбор и доработка', 'Не принимаем первый красивый результат: собираем сцену, исправляем артефакты, выравниваем стиль и движение.'],
+  ['05', 'Финальный ролик', 'Монтаж, композинг, звук и адаптации превращают материал в законченный продукт.'],
+];
+
+function CaseCard({ item }) {
+  return (
+    <a className="ai-video-case" href={item.href}>
+      <div className="ai-video-case__media">
+        <img src={item.image} alt={`Кейс Anix: ${item.title}`} loading="lazy" />
+      </div>
+      <div className="ai-video-case__body">
+        <h3>{item.title}</h3>
+        <p>{item.note}</p>
+        <span>Смотреть кейс <ArrowRight aria-hidden="true" /></span>
+      </div>
+    </a>
+  );
+}
+
+export default function AiVideoPage() {
+  return (
+    <main className="ai-video-page">
+      <header className="ai-video-header">
+        <a href="/" aria-label="Anix Studio — на главную"><BrandLogo alt="Anix Studio" width={120} height={44} /></a>
+        <nav aria-label="Навигация страницы AI-видео">
+          <a href="#capabilities">Возможности</a>
+          <a href="#approach">Подход</a>
+          <a href="#cases">Кейсы</a>
+        </nav>
+        <a className="ai-video-header__cta" href={telegramUrl} target="_blank" rel="noreferrer">Обсудить проект</a>
+      </header>
+
+      <section className="ai-video-hero">
+        <p className="ai-video-eyebrow">Anix Studio / AI-video production</p>
+        <h1>AI-видео с режиссурой, продакшном и вкусом</h1>
+        <p className="ai-video-hero__lead">
+          Anix — полноценная анимационная студия, которая профессионально использует AI внутри продакшна. Не заменяем нейросетями режиссуру — соединяем генеративные инструменты со сценарием, арт-дирекшеном, анимацией и постпродакшном.
+        </p>
+        <div className="ai-video-hero__actions">
+          <a className="ai-video-button ai-video-button--primary" href={telegramUrl} target="_blank" rel="noreferrer">
+            <MessageCircle aria-hidden="true" /> Обсудить задачу
+          </a>
+          <a className="ai-video-button" href="/animation/">Анимационные ролики <ArrowRight aria-hidden="true" /></a>
+        </div>
+        <div className="ai-video-hero__statement">
+          <Sparkles aria-hidden="true" />
+          <p>AI — это часть инструментария. Ценность появляется, когда есть идея, система и человек, который принимает художественные решения.</p>
+        </div>
+      </section>
+
+      <section className="ai-video-section" id="capabilities">
+        <div className="ai-video-section__heading">
+          <p className="ai-video-eyebrow">Что AI действительно даёт</p>
+          <h2>Новые производственные возможности — не новый жанр плохого видео</h2>
+        </div>
+        <div className="ai-video-capabilities">
+          {capabilities.map(({ icon: Icon, title, text }) => (
+            <article key={title}>
+              <Icon aria-hidden="true" />
+              <h3>{title}</h3>
+              <p>{text}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="ai-video-section ai-video-section--dark" id="approach">
+        <div className="ai-video-section__heading">
+          <p className="ai-video-eyebrow">Не AI ради AI</p>
+          <h2>Технология не должна быть заметнее самой идеи</h2>
+        </div>
+        <div className="ai-video-principles">
+          {principles.map(([title, text], index) => (
+            <article key={title}>
+              <span>{String(index + 1).padStart(2, '0')}</span>
+              <div><h3>{title}</h3><p>{text}</p></div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="ai-video-section" id="cases">
+        <div className="ai-video-section__heading ai-video-section__heading--with-link">
+          <div>
+            <p className="ai-video-eyebrow">AI-heavy проекты</p>
+            <h2>От быстрого прототипа до законченного визуального мира</h2>
+          </div>
+          <a href="/cases/">Все кейсы <ArrowRight aria-hidden="true" /></a>
+        </div>
+        <div className="ai-video-cases">
+          {cases.map((item) => <CaseCard item={item} key={item.title} />)}
+        </div>
+      </section>
+
+      <section className="ai-video-section ai-video-control">
+        <div className="ai-video-section__heading">
+          <p className="ai-video-eyebrow">Где нужен контроль</p>
+          <h2>Генеративное видео всё ещё умеет ошибаться красиво</h2>
+        </div>
+        <div className="ai-video-control__grid">
+          <div><ShieldCheck aria-hidden="true" /><h3>Персонажи и лица</h3><p>Следим за идентичностью, анатомией и поведением героя от кадра к кадру.</p></div>
+          <div><Clapperboard aria-hidden="true" /><h3>Монтаж и движение</h3><p>Сцены должны работать вместе, а не быть набором эффектных независимых генераций.</p></div>
+          <div><Film aria-hidden="true" /><h3>Продукт и бренд</h3><p>Там, где нужна точность, используем гибридный пайплайн, графику, 3D и ручной композинг.</p></div>
+        </div>
+      </section>
+
+      <section className="ai-video-section ai-video-process">
+        <div className="ai-video-section__heading">
+          <p className="ai-video-eyebrow">Как работаем</p>
+          <h2>Сначала режиссура. Потом модели.</h2>
+        </div>
+        <div className="ai-video-process__grid">
+          {process.map(([number, title, text]) => (
+            <article key={number}>
+              <span>{number}</span>
+              <h3>{title}</h3>
+              <p>{text}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="ai-video-cta">
+        <p className="ai-video-eyebrow">Есть идея или сложная сцена?</p>
+        <h2>Разберёмся, где AI действительно усиливает проект — и соберём вокруг него нормальный продакшн.</h2>
+        <a href={telegramUrl} target="_blank" rel="noreferrer">Обсудить AI-видео <ArrowRight aria-hidden="true" /></a>
+      </section>
+
+      <SiteFooter />
+    </main>
+  );
+}

--- a/src/components/SiteFooter.jsx
+++ b/src/components/SiteFooter.jsx
@@ -9,6 +9,7 @@ import {
   Pill,
   PlayCircle,
   Sparkles,
+  WandSparkles,
 } from 'lucide-react';
 import { toPublicHref } from '../seo/SeoHead';
 import BrandLogo from './BrandLogo';
@@ -22,6 +23,7 @@ const videoFolderUrl =
 const pageLinks = [
   { label: 'Главная', href: '/' },
   { label: 'Анимационные ролики', href: '/animation' },
+  { label: 'AI-видео', href: '/ai-video' },
   { label: 'Кейсы', href: '/cases' },
   { label: 'Medicine', href: '/medicine' },
   { label: 'HSE', href: '/hse' },
@@ -40,6 +42,11 @@ const directionLinks = [
     label: 'Анимационные ролики',
     href: '/animation',
     icon: Film,
+  },
+  {
+    label: 'AI-видео',
+    href: '/ai-video',
+    icon: WandSparkles,
   },
   {
     label: 'Фарма и MedTech',
@@ -135,6 +142,9 @@ export default function SiteFooter() {
         <span>Anix Studio</span>
         <a href={toPublicHref('/animation')}>
           Анимационные ролики <ArrowRight aria-hidden="true" />
+        </a>
+        <a href={toPublicHref('/ai-video')}>
+          AI-видео <ArrowRight aria-hidden="true" />
         </a>
         <a href={toPublicHref('/medicine')}>
           Medicine <ArrowRight aria-hidden="true" />

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ const WhyItWorksPage = lazy(() => import('./components/WhyItWorksPage'));
 const MedicinePage = lazy(() => import('./components/MedicinePage'));
 const HsePage = lazy(() => import('./components/HsePage'));
 const AnimationPage = lazy(() => import('./components/AnimationPage'));
+const AiVideoPage = lazy(() => import('./components/AiVideoPage'));
 const HseMvpPage = lazy(() => import('./features/hseMvp/HseMvpPage'));
 const Design1TestPage = lazy(() => import('./components/Design1TestPage'));
 const DesignOldPage = lazy(() => import('./components/DesignOldPage'));
@@ -80,6 +81,9 @@ if (normalizedPath === '/hse/mvp' || normalizedPath.startsWith('/hse/mvp/')) {
       break;
     case '/animation':
       renderInLayout(<AnimationPage />);
+      break;
+    case '/ai-video':
+      renderInLayout(<AiVideoPage />);
       break;
     case '/rybki':
     case '/rybki_page':


### PR DESCRIPTION
Adds a new commercial landing page at `/ai-video/` positioning Anix as a full animation studio that professionally uses AI inside a broader production pipeline.

Includes:
- hero and positioning around AI video with directing, art direction, animation and post-production
- sections on what AI genuinely enables
- a strong “not AI for AI’s sake” block
- featured AI-heavy projects: Little Prince, Bondarchuk scene prototype, Borodino, Agrotech, Hemotech AI
- quality-control section covering consistency, editing, product and brand accuracy
- production process from task and script to final video
- links to `/animation/`, cases and Telegram CTA
- SEO metadata, Service schema route config, breadcrumbs and static GitHub Pages route
- footer navigation links for AI video
- runtime smoke-test coverage for `/ai-video/`

Existing Medicine and HSE landing copy is not changed.