### PR TITLE
Fix Rybki slide rendering on mobile

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           node-version: 18
 
+      - name: Install PDF renderer
+        run: sudo apt-get update && sudo apt-get install -y poppler-utils
+
       - name: Cache node modules
         uses: actions/cache@v4
         with:
@@ -42,6 +45,10 @@ jobs:
       - name: Notify if install failed
         if: steps.npm-install.outcome == 'failure'
         run: echo "npm install failed"
+
+      - name: Render Rybki slide previews
+        if: steps.npm-install.outcome == 'success'
+        run: node scripts/render-rybki-pdf-slides.js
 
       - name: Build and verify static SEO
         if: steps.npm-install.outcome == 'success'

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -19,6 +19,9 @@ jobs:
           node-version: 18
           cache: npm
 
+      - name: Install PDF renderer
+        run: sudo apt-get update && sudo apt-get install -y poppler-utils
+
       - name: Install dependencies
         run: npm install
 
@@ -29,6 +32,9 @@ jobs:
         env:
           CI: true
         run: npm test -- --watchAll=false
+
+      - name: Render Rybki slide previews
+        run: node scripts/render-rybki-pdf-slides.js
 
       - name: Production build and SEO verification
         env:

--- a/scripts/render-rybki-pdf-slides.js
+++ b/scripts/render-rybki-pdf-slides.js
@@ -1,0 +1,46 @@
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const sharp = require('sharp');
+
+const root = path.resolve(__dirname, '..');
+const sourceDir = path.join(root, 'public', 'rybki-assets');
+const outputDir = path.join(root, 'public', 'rybki-rendered');
+const widths = [720, 1280, 1920];
+
+function commandExists(command) {
+  return spawnSync('which', [command], { encoding: 'utf8' }).status === 0;
+}
+
+async function main() {
+  if (!commandExists('pdftoppm')) {
+    throw new Error('pdftoppm is required. Install poppler-utils before the production build.');
+  }
+
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  for (let index = 1; index <= 10; index += 1) {
+    const pdf = path.join(sourceDir, `Слайд ${index}.pdf`);
+    const tempPrefix = path.join(outputDir, `slide-${index}-source`);
+    const png = `${tempPrefix}.png`;
+    if (!fs.existsSync(pdf)) throw new Error(`Missing Rybki PDF: ${pdf}`);
+
+    const render = spawnSync('pdftoppm', ['-f', '1', '-singlefile', '-png', '-r', '180', pdf, tempPrefix], { stdio: 'inherit' });
+    if (render.status !== 0 || !fs.existsSync(png)) throw new Error(`Failed to render ${path.basename(pdf)}`);
+
+    for (const width of widths) {
+      const output = path.join(outputDir, `slide-${index}-${width}.webp`);
+      await sharp(png)
+        .resize({ width, withoutEnlargement: true })
+        .webp({ quality: width === 1920 ? 84 : 80, effort: 6 })
+        .toFile(output);
+    }
+
+    fs.unlinkSync(png);
+  }
+}
+
+main().catch((error) => {
+  console.error('[rybki-pdf] render failed', error);
+  process.exit(1);
+});

--- a/scripts/render-rybki-pdf-slides.js
+++ b/scripts/render-rybki-pdf-slides.js
@@ -25,14 +25,18 @@ async function main() {
     const png = `${tempPrefix}.png`;
     if (!fs.existsSync(pdf)) throw new Error(`Missing Rybki PDF: ${pdf}`);
 
-    const render = spawnSync('pdftoppm', ['-f', '1', '-singlefile', '-png', '-r', '180', pdf, tempPrefix], { stdio: 'inherit' });
+    const render = spawnSync(
+      'pdftoppm',
+      ['-f', '1', '-singlefile', '-png', '-scale-to-x', '1920', '-scale-to-y', '-1', pdf, tempPrefix],
+      { stdio: 'inherit' },
+    );
     if (render.status !== 0 || !fs.existsSync(png)) throw new Error(`Failed to render ${path.basename(pdf)}`);
 
     for (const width of widths) {
       const output = path.join(outputDir, `slide-${index}-${width}.webp`);
       await sharp(png)
         .resize({ width, withoutEnlargement: true })
-        .webp({ quality: width === 1920 ? 84 : 80, effort: 6 })
+        .webp({ quality: width === 1920 ? 84 : 80, effort: 5 })
         .toFile(output);
     }
 

--- a/src/components/RybkiPage.jsx
+++ b/src/components/RybkiPage.jsx
@@ -6,12 +6,14 @@ import './RybkiPdfSlides.css';
 const telegramUrl = 'https://t.me/anix_helper';
 
 const slides = Array.from({ length: 10 }, (_, index) => ({
+  number: index + 1,
   file: `Слайд ${index + 1}.pdf`,
   label: `Слайд ${index + 1}`,
 }));
 
 function Slide({ slide, index }) {
-  const pdfUrl = `/rybki-assets/${encodeURIComponent(slide.file)}#toolbar=0&navpanes=0&scrollbar=0&view=FitH`;
+  const pdfUrl = `/rybki-assets/${encodeURIComponent(slide.file)}`;
+  const imageBase = `/rybki-rendered/slide-${slide.number}`;
 
   return (
     <section className="rybki-slide" id={`slide-${index + 1}`}>
@@ -20,14 +22,25 @@ function Slide({ slide, index }) {
         <span>{slide.label}</span>
       </div>
       <div className="rybki-slide-frame">
-        <iframe
-          className="rybki-slide-pdf"
-          src={pdfUrl}
-          title={`Рыбки — ${slide.label}`}
-          loading={index === 0 ? 'eager' : 'lazy'}
-        />
+        <picture>
+          <source
+            type="image/webp"
+            srcSet={`${imageBase}-720.webp 720w, ${imageBase}-1280.webp 1280w, ${imageBase}-1920.webp 1920w`}
+            sizes="(max-width: 800px) 94vw, calc(96vw - 174px)"
+          />
+          <img
+            className="rybki-slide-image"
+            src={`${imageBase}-1280.webp`}
+            alt={`Кадр презентации «Рыбки» — ${slide.label}`}
+            width="1920"
+            height="1080"
+            loading={index === 0 ? 'eager' : 'lazy'}
+            fetchPriority={index === 0 ? 'high' : 'auto'}
+            decoding={index === 0 ? 'sync' : 'async'}
+          />
+        </picture>
         <a className="rybki-slide-open" href={pdfUrl} target="_blank" rel="noreferrer">
-          Открыть слайд отдельно
+          Открыть PDF
         </a>
       </div>
     </section>

--- a/src/components/RybkiPdfSlides.css
+++ b/src/components/RybkiPdfSlides.css
@@ -1,8 +1,14 @@
-.rybki-slide-pdf {
+.rybki-slide-frame picture {
   display: block;
   width: 100%;
   height: 100%;
-  border: 0;
+}
+
+.rybki-slide-image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
   background: #08121b;
 }
 


### PR DESCRIPTION
Clean mobile fix for `/rybki/`: keep uploaded PDFs as source files, render page 1 of each PDF to responsive WebP previews in CI/deploy, display those previews with `<picture>` instead of embedded PDF iframes, and keep a direct PDF link as a secondary action.