### PR TITLE
Let admins delete any user from the admin dashboard

### DIFF
--- a/src/features/hseMvp/HseMvpPage.jsx
+++ b/src/features/hseMvp/HseMvpPage.jsx
@@ -68,6 +68,7 @@ import {
 } from './lib/hseSupabase';
 import {
   SELF_REGISTER_ROLES,
+  adminDeleteUser,
   deleteOwnAccount,
   fetchDepartmentSlug,
   fetchOwnProfile,
@@ -3037,6 +3038,7 @@ function RealAdminDashboard() {
   const [events, setEvents] = useState([]);
   const [error, setError] = useState('');
   const [busyUserId, setBusyUserId] = useState('');
+  const [deleteConfirmingId, setDeleteConfirmingId] = useState('');
 
   const reload = async () => {
     try {
@@ -3068,6 +3070,20 @@ function RealAdminDashboard() {
     }
   };
 
+  const handleDeleteUser = async (userId) => {
+    setBusyUserId(userId);
+    setError('');
+    try {
+      await adminDeleteUser(userId);
+      setDeleteConfirmingId('');
+      await reload();
+    } catch (deleteError) {
+      setError(deleteError.message || 'Не удалось удалить пользователя.');
+    } finally {
+      setBusyUserId('');
+    }
+  };
+
   return (
     <div className="hse-mvp-panel">
       <div className="hse-mvp-actions">
@@ -3084,6 +3100,7 @@ function RealAdminDashboard() {
               <th>Роль</th>
               <th>Регистрация</th>
               <th>Изменить роль</th>
+              <th>Удалить</th>
             </tr>
           </thead>
           <tbody>
@@ -3105,6 +3122,38 @@ function RealAdminDashboard() {
                     <option value="specialist">Специалист</option>
                     <option value="admin">Администратор</option>
                   </select>
+                </td>
+                <td>
+                  {deleteConfirmingId === item.user_id ? (
+                    <div className="hse-mvp-actions">
+                      <button
+                        className="hse-mvp-button hse-mvp-button-danger"
+                        type="button"
+                        disabled={busyUserId === item.user_id}
+                        onClick={() => handleDeleteUser(item.user_id)}
+                      >
+                        {busyUserId === item.user_id
+                          ? 'Удаление…'
+                          : 'Точно удалить'}
+                      </button>
+                      <button
+                        className="hse-mvp-button"
+                        type="button"
+                        disabled={busyUserId === item.user_id}
+                        onClick={() => setDeleteConfirmingId('')}
+                      >
+                        Отмена
+                      </button>
+                    </div>
+                  ) : (
+                    <button
+                      className="hse-mvp-button"
+                      type="button"
+                      onClick={() => setDeleteConfirmingId(item.user_id)}
+                    >
+                      Удалить
+                    </button>
+                  )}
                 </td>
               </tr>
             ))}

--- a/src/features/hseMvp/lib/auth.ts
+++ b/src/features/hseMvp/lib/auth.ts
@@ -146,6 +146,31 @@ export const updateProfileRole = async (userId: string, role: HseRole) => {
   if (error) throw error;
 };
 
+// Same constraint as deleteOwnAccount: deleting a user needs the
+// service-role key, so this calls admin-delete-user, which re-checks the
+// caller's own admin role server-side before deleting anyone.
+export const adminDeleteUser = async (targetUserId: string) => {
+  const client = requireClient();
+  const config = getHseSupabaseConfig();
+  const { data: sessionData } = await client.auth.getSession();
+  const token = sessionData?.session?.access_token;
+  if (!token) throw new Error('Не найдена активная сессия.');
+
+  const response = await fetch(`${config.url}/functions/v1/admin-delete-user`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+      apikey: config.anonKey,
+    },
+    body: JSON.stringify({ targetUserId }),
+  });
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}) as any);
+    throw new Error(body?.error || 'Не удалось удалить пользователя.');
+  }
+};
+
 export const fetchDepartmentSlug = async (departmentId: string | null) => {
   if (!departmentId) return null;
   const client = getHseSupabaseClient();

--- a/supabase/functions/admin-delete-user/index.ts
+++ b/supabase/functions/admin-delete-user/index.ts
@@ -1,0 +1,61 @@
+// Self-contained on purpose (no shared imports) — deployable either via
+// the Supabase CLI or by pasting straight into the Dashboard's editor,
+// same as delete-account/index.ts.
+const CORS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'content-type, authorization, x-client-info, apikey',
+  'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+};
+
+function json(body: any, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...CORS },
+  });
+}
+
+async function handler(req: Request): Promise<Response> {
+  if (req.method === 'OPTIONS') return new Response(null, { status: 204, headers: CORS });
+  if (req.method !== 'POST') return json({ error: 'method_not_allowed' }, 405);
+
+  try {
+    const authHeader = req.headers.get('authorization') || '';
+    const token = authHeader.replace(/^Bearer\s+/i, '');
+    if (!token) return json({ error: 'missing_token' }, 401);
+
+    const { targetUserId } = await req.json();
+    if (!targetUserId) return json({ error: 'missing_target_user_id' }, 400);
+
+    const SUPABASE_URL = Deno.env.get('SUPABASE_URL');
+    const SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+    if (!SUPABASE_URL || !SERVICE_ROLE_KEY) return json({ error: 'misconfigured' }, 500);
+
+    const { createClient } = await import('https://esm.sh/@supabase/supabase-js@2');
+    const admin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+
+    // Resolve the caller's own identity from their JWT, then check their
+    // role server-side — never trust a client-supplied "I am admin" claim.
+    const { data: callerData, error: callerError } = await admin.auth.getUser(token);
+    if (callerError || !callerData?.user) return json({ error: 'invalid_session' }, 401);
+
+    const { data: callerProfile, error: profileError } = await admin
+      .from('hse_profiles')
+      .select('role')
+      .eq('user_id', callerData.user.id)
+      .maybeSingle();
+    if (profileError) return json({ error: 'profile_lookup_failed' }, 500);
+    if (callerProfile?.role !== 'admin') return json({ error: 'forbidden' }, 403);
+
+    const { error: deleteError } = await admin.auth.admin.deleteUser(targetUserId);
+    if (deleteError) return json({ error: 'delete_failed' }, 500);
+
+    return json({ ok: true });
+  } catch (_err) {
+    return json({ error: 'unexpected_error' }, 500);
+  }
+}
+
+if (typeof Deno !== 'undefined' && typeof (Deno as any).serve === 'function') {
+  (Deno as any).serve(handler);
+}
+export default handler;


### PR DESCRIPTION
Adds a per-row Delete button (two-step confirm) to the admin user table. Backed by a new admin-delete-user Edge Function, since deleting someone else's auth.users row needs the service-role key — the function re-derives the caller's identity from their own JWT and checks their hse_profiles.role server-side before deleting the target user, so only a real admin can use it and only via their own session.