### PR TITLE
Verify YouTube embed compatibility fix

### DIFF
--- a/docs/YOUTUBE_EMBED_FIX_VERIFIED.md
+++ b/docs/YOUTUBE_EMBED_FIX_VERIFIED.md
@@ -1,0 +1,3 @@
+# YouTube embed fix verification
+
+This branch exists to run the full quality pipeline after switching the non-Russian showreel from `youtube-nocookie.com` to the regular authenticated YouTube embed and adding a direct fallback link.


### PR DESCRIPTION
Runs the full quality pipeline after switching the non-Russian showreel to the regular YouTube embed with the production origin and adding a direct YouTube fallback link.