### PR TITLE
Fix Aviandr images across case pages and video posters

### DIFF
--- a/docs/AVIANDR_IMAGE_FIX_VERIFICATION.md
+++ b/docs/AVIANDR_IMAGE_FIX_VERIFICATION.md
@@ -1,0 +1,3 @@
+# Aviandr image fix verification
+
+This branch verifies that the committed `src/images/cases/aviandr-cover.webp` and `aviandr-koala.webp` assets are used by the dedicated case page, video posters, cases hub, medicine category and generated static SEO output.

--- a/scripts/ensure-aviandr-case-route.js
+++ b/scripts/ensure-aviandr-case-route.js
@@ -2,6 +2,18 @@ const fs = require('fs');
 const path = require('path');
 
 const filePath = path.resolve(__dirname, '../src/seo/routes.json');
+const sourceCoverPath = path.resolve(__dirname, '../src/images/cases/aviandr-cover.webp');
+const publicCoverDirectory = path.resolve(__dirname, '../public/seo-media/cases');
+const publicCoverPath = path.join(publicCoverDirectory, 'aviandr-cover.webp');
+const publicCoverUrl = '/seo-media/cases/aviandr-cover.webp';
+
+if (!fs.existsSync(sourceCoverPath)) {
+  throw new Error(`[aviandr-case] Missing cover source: ${sourceCoverPath}`);
+}
+
+fs.mkdirSync(publicCoverDirectory, { recursive: true });
+fs.copyFileSync(sourceCoverPath, publicCoverPath);
+
 const config = JSON.parse(fs.readFileSync(filePath, 'utf8'));
 const routePath = '/cases/aviandr';
 
@@ -9,39 +21,53 @@ config.routes[routePath] = {
   indexable: true,
   kind: 'case',
   title: 'Кейс Авиандр: медицинская анимация и маскоты препарата — ANIX Studio',
-  description: 'Кейс ANIX Studio для Авиандра: научно корректный анимационный ролик, Доктор Коала, визуализация доказательной базы и работа ролика на конференционном стенде.',
+  description:
+    'Кейс ANIX Studio для Авиандра: научно корректный анимационный ролик, Доктор Коала, визуализация доказательной базы и работа ролика на конференционном стенде.',
   ogTitle: 'Авиандр — медицинская анимация и маскоты препарата',
-  ogDescription: 'Как превратить доказательную базу препарата в понятную визуальную историю и привлечь внимание врачей на конференции.',
-  ogImage: '/og/medicine.jpg',
+  ogDescription:
+    'Как превратить доказательную базу препарата в понятную визуальную историю и привлечь внимание врачей на конференции.',
+  ogImage: publicCoverUrl,
   h1: 'Авиандр: доказательная база, которая работает на доверие',
-  intro: 'Для препарата Авиандр мы собрали научно корректный анимационный ролик, визуальный язык и маскотов, которые помогают объяснять сложное и привлекать внимание врачей.',
+  intro:
+    'Для препарата Авиандр мы собрали научно корректный анимационный ролик, визуальный язык и маскотов, которые помогают объяснять сложное и привлекать внимание врачей.',
   case: {
     category: 'Фарма / медицинская анимация',
     result: 'Ролик стал центром внимания на стенде',
     tags: 'фарма / доказательная база / маскоты / конференция',
-    image: '/images/cases/aviandr.webp',
+    image: publicCoverUrl,
     imageAlt: 'Доктор Коала и маскот Авиандр — медицинский кейс ANIX Studio',
-    placeholder: 'А',
     videoUrl: 'https://vkvideo.ru/video-174933827_456239053',
-    relatedPath: '/medicine'
+    relatedPath: '/medicine',
   },
   sections: [
-    { heading: 'Задача', body: 'Перевести доказательную базу, механизм действия, безопасность и эффективность препарата в понятную визуальную историю для врачебной аудитории.' },
-    { heading: 'Маскоты', body: 'Мы исследовали разные варианты образов и остановились на Докторе Коале — спокойном, умном и заботливом проводнике по сложной медицинской информации.' },
-    { heading: 'На конференции', body: 'Клиент использовал ролик на стенде: видео привлекало внимание, люди подходили, останавливались и досматривали материал.' },
-    { heading: 'Результат', body: 'Ролик стал не только объясняющим материалом, но и заметным инструментом оформления стенда и коммуникации с врачами.' }
+    {
+      heading: 'Задача',
+      body: 'Перевести доказательную базу, механизм действия, безопасность и эффективность препарата в понятную визуальную историю для врачебной аудитории.',
+    },
+    {
+      heading: 'Маскоты',
+      body: 'Мы исследовали разные варианты образов и остановились на Докторе Коале — спокойном, умном и заботливом проводнике по сложной медицинской информации.',
+    },
+    {
+      heading: 'На конференции',
+      body: 'Клиент использовал ролик на стенде: видео привлекало внимание, люди подходили, останавливались и досматривали материал.',
+    },
+    {
+      heading: 'Результат',
+      body: 'Ролик стал не только объясняющим материалом, но и заметным инструментом оформления стенда и коммуникации с врачами.',
+    },
   ],
   links: [
     { label: 'Медицинские и фармацевтические ролики', href: '/medicine' },
     { label: 'Все кейсы ANIX', href: '/cases' },
-    { label: 'ANIX Studio', href: '/' }
+    { label: 'ANIX Studio', href: '/' },
   ],
   breadcrumbs: [
     { label: 'Главная', href: '/' },
     { label: 'Кейсы', href: '/cases' },
-    { label: 'Авиандр', href: routePath }
-  ]
+    { label: 'Авиандр', href: routePath },
+  ],
 };
 
 fs.writeFileSync(filePath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
-console.log(`[aviandr-case] ensured ${routePath}`);
+console.log(`[aviandr-case] ensured ${routePath} and copied ${publicCoverUrl}`);

--- a/src/components/AviandrCasePage.jsx
+++ b/src/components/AviandrCasePage.jsx
@@ -1,16 +1,28 @@
 import React, { useState } from 'react';
 import { ArrowLeft, ExternalLink, MessageCircle, Play, Sparkles } from 'lucide-react';
+import aviandrCoverImage from '../images/cases/aviandr-cover.webp';
+import aviandrKoalaImage from '../images/cases/aviandr-koala.webp';
 import BrandLogo from './BrandLogo';
 import SiteFooter from './SiteFooter';
 import './AviandrCasePage.css';
 
 const TELEGRAM_URL = 'https://t.me/anix_helper';
 const FALLBACK_IMAGE = '/og/medicine.jpg';
-const COVER_IMAGE = '/seo-media/cases/aviandr-cover.webp';
-const KOALA_IMAGE = '/seo-media/cases/aviandr-koala.webp';
+const COVER_IMAGE = aviandrCoverImage;
+const KOALA_IMAGE = aviandrKoalaImage;
 const VIDEOS = {
-  main: { embed: 'https://vkvideo.ru/video_ext.php?oid=-174933827&id=456239053&hash=3e590888196f8faa&hd=3&autoplay=1', external: 'https://vkvideo.ru/video-174933827_456239053', title: 'Авиандр: доказательная база — анимационный ролик ANIX Studio' },
-  conference: { embed: 'https://vkvideo.ru/video_ext.php?oid=-174933827&id=456239054&hash=d9b9ce95e65e21be&hd=3&autoplay=1', external: 'https://vkvideo.ru/video-174933827_456239054', title: 'Как ролик Авиандр работал на конференционном стенде' },
+  main: {
+    embed:
+      'https://vkvideo.ru/video_ext.php?oid=-174933827&id=456239053&hash=3e590888196f8faa&hd=3&autoplay=1',
+    external: 'https://vkvideo.ru/video-174933827_456239053',
+    title: 'Авиандр: доказательная база — анимационный ролик ANIX Studio',
+  },
+  conference: {
+    embed:
+      'https://vkvideo.ru/video_ext.php?oid=-174933827&id=456239054&hash=d9b9ce95e65e21be&hd=3&autoplay=1',
+    external: 'https://vkvideo.ru/video-174933827_456239054',
+    title: 'Как ролик Авиандр работал на конференционном стенде',
+  },
 };
 
 function useFallbackImage(event) {
@@ -20,30 +32,228 @@ function useFallbackImage(event) {
 
 function LazyVkVideo({ video, poster, posterAlt }) {
   const [started, setStarted] = useState(false);
-  return <div className="aviandr-video">
-    {started ? <iframe src={video.embed} width="1280" height="720" title={video.title} allow="autoplay; encrypted-media; fullscreen; picture-in-picture; screen-wake-lock;" frameBorder="0" allowFullScreen referrerPolicy="strict-origin-when-cross-origin" /> :
-      <button type="button" className="aviandr-video-poster" onClick={() => setStarted(true)} aria-label={`Смотреть: ${video.title}`}><img src={poster} alt={posterAlt} width="1280" height="720" decoding="async" onError={useFallbackImage} /><span><Play aria-hidden="true" />Смотреть видео</span></button>}
-    <a href={video.external} target="_blank" rel="noreferrer">Открыть во VK Видео <ExternalLink aria-hidden="true" /></a>
-  </div>;
+
+  return (
+    <div className="aviandr-video">
+      {started ? (
+        <iframe
+          src={video.embed}
+          width="1280"
+          height="720"
+          title={video.title}
+          allow="autoplay; encrypted-media; fullscreen; picture-in-picture; screen-wake-lock;"
+          frameBorder="0"
+          allowFullScreen
+          referrerPolicy="strict-origin-when-cross-origin"
+        />
+      ) : (
+        <button
+          type="button"
+          className="aviandr-video-poster"
+          onClick={() => setStarted(true)}
+          aria-label={`Смотреть: ${video.title}`}
+        >
+          <img
+            src={poster}
+            alt={posterAlt}
+            width="1280"
+            height="720"
+            decoding="async"
+            onError={useFallbackImage}
+          />
+          <span>
+            <Play aria-hidden="true" />
+            Смотреть видео
+          </span>
+        </button>
+      )}
+      <a href={video.external} target="_blank" rel="noreferrer">
+        Открыть во VK Видео <ExternalLink aria-hidden="true" />
+      </a>
+    </div>
+  );
 }
 
 export default function AviandrCasePage() {
-  return <main className="aviandr-case-page">
-    <header className="aviandr-header"><a href="/" aria-label="ANIX Studio — на главную"><BrandLogo alt="ANIX Studio" width={116} height={42} /></a><nav aria-label="Навигация по кейсу"><a href="/cases/">Кейсы</a><a href="#mascot">Маскот</a><a href="#conference">Конференция</a></nav><a className="aviandr-header-cta" href={TELEGRAM_URL} target="_blank" rel="noreferrer">Обсудить проект</a></header>
+  return (
+    <main className="aviandr-case-page">
+      <header className="aviandr-header">
+        <a href="/" aria-label="ANIX Studio — на главную">
+          <BrandLogo alt="ANIX Studio" width={116} height={42} />
+        </a>
+        <nav aria-label="Навигация по кейсу">
+          <a href="/cases/">Кейсы</a>
+          <a href="#mascot">Маскот</a>
+          <a href="#conference">Конференция</a>
+        </nav>
+        <a className="aviandr-header-cta" href={TELEGRAM_URL} target="_blank" rel="noreferrer">
+          Обсудить проект
+        </a>
+      </header>
 
-    <section className="aviandr-hero"><div className="aviandr-hero-copy"><a className="aviandr-back" href="/cases/"><ArrowLeft aria-hidden="true" /> Все кейсы</a><p className="aviandr-eyebrow">Фармацевтика / медицинская анимация</p><h1>Авиандр: доказательная база, которая работает на доверие</h1><p className="aviandr-lead">Анимационный ролик о препарате для врачей. Объясняем сложное через персонажей, атмосферу и внимание к научным деталям.</p><div className="aviandr-pill-row"><span>Доктор Коала</span><span>доказательная база</span><span>конференционный стенд</span></div></div><figure className="aviandr-hero-visual"><img src={COVER_IMAGE} alt="Доктор Коала и маскот буква А — визуальный мир препарата Авиандр" width="1920" height="1080" fetchPriority="high" onError={useFallbackImage} /></figure></section>
+      <section className="aviandr-hero">
+        <div className="aviandr-hero-copy">
+          <a className="aviandr-back" href="/cases/">
+            <ArrowLeft aria-hidden="true" /> Все кейсы
+          </a>
+          <p className="aviandr-eyebrow">Фармацевтика / медицинская анимация</p>
+          <h1>Авиандр: доказательная база, которая работает на доверие</h1>
+          <p className="aviandr-lead">
+            Анимационный ролик о препарате для врачей. Объясняем сложное через персонажей,
+            атмосферу и внимание к научным деталям.
+          </p>
+          <div className="aviandr-pill-row">
+            <span>Доктор Коала</span>
+            <span>доказательная база</span>
+            <span>конференционный стенд</span>
+          </div>
+        </div>
+        <figure className="aviandr-hero-visual">
+          <img
+            src={COVER_IMAGE}
+            alt="Доктор Коала и маскот буква А — визуальный мир препарата Авиандр"
+            width="1920"
+            height="1080"
+            fetchPriority="high"
+            onError={useFallbackImage}
+          />
+        </figure>
+      </section>
 
-    <section className="aviandr-section aviandr-task"><div><p className="aviandr-eyebrow">01 / Задача</p><h2>Объяснить препарат без перегруза и рекламного шума</h2></div><p>Нужно было собрать понятную историю о доказательной базе, механизме действия, безопасности и эффективности препарата — так, чтобы материал удерживал внимание врачей и при этом не упрощал научную логику до банального рекламного обещания.</p><div className="aviandr-card-grid"><article><span>Научная точность</span><h3>Сохраняем утверждённую медицинскую логику и причинно-следственные связи</h3></article><article><span>Внимание</span><h3>Делаем данные визуальной историей, которую хочется досмотреть</h3></article><article><span>Доверие</span><h3>Безопасность, эффективность и доказательность остаются в центре коммуникации</h3></article></div></section>
+      <section className="aviandr-section aviandr-task">
+        <div>
+          <p className="aviandr-eyebrow">01 / Задача</p>
+          <h2>Объяснить препарат без перегруза и рекламного шума</h2>
+        </div>
+        <p>
+          Нужно было собрать понятную историю о доказательной базе, механизме действия,
+          безопасности и эффективности препарата — так, чтобы материал удерживал внимание врачей
+          и при этом не упрощал научную логику до банального рекламного обещания.
+        </p>
+        <div className="aviandr-card-grid">
+          <article>
+            <span>Научная точность</span>
+            <h3>Сохраняем утверждённую медицинскую логику и причинно-следственные связи</h3>
+          </article>
+          <article>
+            <span>Внимание</span>
+            <h3>Делаем данные визуальной историей, которую хочется досмотреть</h3>
+          </article>
+          <article>
+            <span>Доверие</span>
+            <h3>Безопасность, эффективность и доказательность остаются в центре коммуникации</h3>
+          </article>
+        </div>
+      </section>
 
-    <section className="aviandr-section aviandr-mascot" id="mascot"><div className="aviandr-mascot-copy"><p className="aviandr-eyebrow">02 / Поиск маскота</p><h2>Мы искали разные образы — и сошлись на коале</h2><p>Вариантов было много: более абстрактные символы, технологичные персонажи и разные животные. Но для медицинской коммуникации был нужен не герой-шоумен, а спокойный проводник — умный, доброжелательный и достаточно взрослый, чтобы говорить с врачебной аудиторией.</p><div className="aviandr-mascot-insight"><Sparkles aria-hidden="true" /><div><strong>Почему коала</strong><span>Она не отвлекает от сути, но делает сложные темы ближе, теплее и запоминаемее.</span></div></div></div><figure><img src={KOALA_IMAGE} alt="Один из образов Доктора Коалы, выбранного маскотом проекта Авиандр" width="1200" height="673" loading="lazy" decoding="async" onError={useFallbackImage} /><figcaption>Доктор Коала — спокойный эксперт и проводник по доказательной базе препарата.</figcaption></figure></section>
+      <section className="aviandr-section aviandr-mascot" id="mascot">
+        <div className="aviandr-mascot-copy">
+          <p className="aviandr-eyebrow">02 / Поиск маскота</p>
+          <h2>Мы искали разные образы — и сошлись на коале</h2>
+          <p>
+            Вариантов было много: более абстрактные символы, технологичные персонажи и разные
+            животные. Но для медицинской коммуникации был нужен не герой-шоумен, а спокойный
+            проводник — умный, доброжелательный и достаточно взрослый, чтобы говорить с врачебной
+            аудиторией.
+          </p>
+          <div className="aviandr-mascot-insight">
+            <Sparkles aria-hidden="true" />
+            <div>
+              <strong>Почему коала</strong>
+              <span>
+                Она не отвлекает от сути, но делает сложные темы ближе, теплее и запоминаемее.
+              </span>
+            </div>
+          </div>
+        </div>
+        <figure>
+          <img
+            src={KOALA_IMAGE}
+            alt="Один из образов Доктора Коалы, выбранного маскотом проекта Авиандр"
+            width="1200"
+            height="673"
+            loading="lazy"
+            decoding="async"
+            onError={useFallbackImage}
+          />
+          <figcaption>
+            Доктор Коала — спокойный эксперт и проводник по доказательной базе препарата.
+          </figcaption>
+        </figure>
+      </section>
 
-    <section className="aviandr-section aviandr-main-video"><div className="aviandr-section-heading"><p className="aviandr-eyebrow">03 / Ролик</p><h2>Доказательная база как визуальная история</h2></div><p className="aviandr-section-intro">В ролике научные исследования, безопасность и эффективность не превращаются в набор слайдов. Доктор Коала и маскот «А» ведут зрителя через материал, удерживая единую интонацию и визуальный язык.</p><LazyVkVideo video={VIDEOS.main} poster={COVER_IMAGE} posterAlt="Обложка анимационного ролика Авиандр" /></section>
+      <section className="aviandr-section aviandr-main-video">
+        <div className="aviandr-section-heading">
+          <p className="aviandr-eyebrow">03 / Ролик</p>
+          <h2>Доказательная база как визуальная история</h2>
+        </div>
+        <p className="aviandr-section-intro">
+          В ролике научные исследования, безопасность и эффективность не превращаются в набор
+          слайдов. Доктор Коала и маскот «А» ведут зрителя через материал, удерживая единую интонацию
+          и визуальный язык.
+        </p>
+        <LazyVkVideo
+          video={VIDEOS.main}
+          poster={COVER_IMAGE}
+          posterAlt="Обложка анимационного ролика Авиандр"
+        />
+      </section>
 
-    <section className="aviandr-section aviandr-conference" id="conference"><div className="aviandr-conference-copy"><p className="aviandr-eyebrow">04 / В полевых условиях</p><h2>Ролик стал частью стенда и действительно собирал внимание</h2><p>Клиент прислал видео с конференции: люди подходили к экрану, останавливались, смотрели и обсуждали материал. Ролик работал уже не как отдельный файл, а как заметный элемент пространства и первое касание с препаратом.</p><blockquote>«Очень украшает сделанный вами ролик наш стенд. Спасибо огромное!»<cite>Алексей, маркетинговый директор «Авинейро»</cite></blockquote></div><LazyVkVideo video={VIDEOS.conference} poster={COVER_IMAGE} posterAlt="Видео использования ролика Авиандр на конференции" /></section>
+      <section className="aviandr-section aviandr-conference" id="conference">
+        <div className="aviandr-conference-copy">
+          <p className="aviandr-eyebrow">04 / В полевых условиях</p>
+          <h2>Ролик стал частью стенда и действительно собирал внимание</h2>
+          <p>
+            Клиент прислал видео с конференции: люди подходили к экрану, останавливались, смотрели и
+            обсуждали материал. Ролик работал уже не как отдельный файл, а как заметный элемент
+            пространства и первое касание с препаратом.
+          </p>
+          <blockquote>
+            «Очень украшает сделанный вами ролик наш стенд. Спасибо огромное!»
+            <cite>Алексей, маркетинговый директор «Авинейро»</cite>
+          </blockquote>
+        </div>
+        <LazyVkVideo
+          video={VIDEOS.conference}
+          poster={COVER_IMAGE}
+          posterAlt="Видео использования ролика Авиандр на конференции"
+        />
+      </section>
 
-    <section className="aviandr-result"><p className="aviandr-eyebrow">Результат</p><h2>Не просто красивый ролик, а инструмент коммуникации</h2><div><article><span>01</span><h3>Объясняет сложное</h3><p>Исследования и медицинские данные собраны в последовательную визуальную историю.</p></article><article><span>02</span><h3>Усиливает доверие</h3><p>Подача поддерживает доказательный характер препарата и уважает врачебную аудиторию.</p></article><article><span>03</span><h3>Работает офлайн</h3><p>На конференции ролик привлекал внимание и помогал начинать разговор у стенда.</p></article></div></section>
+      <section className="aviandr-result">
+        <p className="aviandr-eyebrow">Результат</p>
+        <h2>Не просто красивый ролик, а инструмент коммуникации</h2>
+        <div>
+          <article>
+            <span>01</span>
+            <h3>Объясняет сложное</h3>
+            <p>Исследования и медицинские данные собраны в последовательную визуальную историю.</p>
+          </article>
+          <article>
+            <span>02</span>
+            <h3>Усиливает доверие</h3>
+            <p>Подача поддерживает доказательный характер препарата и уважает врачебную аудиторию.</p>
+          </article>
+          <article>
+            <span>03</span>
+            <h3>Работает офлайн</h3>
+            <p>На конференции ролик привлекал внимание и помогал начинать разговор у стенда.</p>
+          </article>
+        </div>
+      </section>
 
-    <section className="aviandr-cta"><p className="aviandr-eyebrow">Следующий проект</p><h2>Нужно показать сложный медицинский продукт понятно и точно?</h2><p>Соберём научную карту, сценарий, визуальный язык, маскотов и ролик под врачей, конференции и продажи.</p><a href={TELEGRAM_URL} target="_blank" rel="noreferrer"><MessageCircle aria-hidden="true" /> Обсудить проект</a></section>
-    <SiteFooter />
-  </main>;
+      <section className="aviandr-cta">
+        <p className="aviandr-eyebrow">Следующий проект</p>
+        <h2>Нужно показать сложный медицинский продукт понятно и точно?</h2>
+        <p>
+          Соберём научную карту, сценарий, визуальный язык, маскотов и ролик под врачей, конференции
+          и продажи.
+        </p>
+        <a href={TELEGRAM_URL} target="_blank" rel="noreferrer">
+          <MessageCircle aria-hidden="true" /> Обсудить проект
+        </a>
+      </section>
+      <SiteFooter />
+    </main>
+  );
 }

--- a/src/components/CasesCategoryPage.jsx
+++ b/src/components/CasesCategoryPage.jsx
@@ -3,6 +3,7 @@ import { ArrowLeft, ArrowRight, Camera, HardHat, Stethoscope, Workflow } from 'l
 import BrandLogo from './BrandLogo';
 import SiteFooter from './SiteFooter';
 import agrotechImage from '../images/cases/agrotech.webp';
+import aviandrCoverImage from '../images/cases/aviandr-cover.webp';
 import bondarchukImage from '../images/cases/bondarchuk.webp';
 import borodinoImage from '../images/cases/borodino.webp';
 import clappyImage from '../images/cases/clappy.webp';
@@ -21,60 +22,218 @@ import './CasesCategoryPage.css';
 
 const categoryConfig = {
   '/cases/b2b': {
-    eyebrow: 'B2B / Technology', title: 'Технологии, B2B и сложные продукты',
-    description: 'Кейсы для продуктов, которые трудно объяснить одним слайдом: сложная механика, новая категория, длинный цикл продажи или профессиональная аудитория.', icon: Workflow,
+    eyebrow: 'B2B / Technology',
+    title: 'Технологии, B2B и сложные продукты',
+    description:
+      'Кейсы для продуктов, которые трудно объяснить одним слайдом: сложная механика, новая категория, длинный цикл продажи или профессиональная аудитория.',
+    icon: Workflow,
     cases: [
-      { title: 'Factory Director', image: factoryDirectorImage, note: 'Маскот и конференционный ролик для сложного B2B-продукта.' },
-      { title: 'Стартех', image: startechImage, note: 'Переупаковка продукта и объясняющий ролик для регионального B2B.' },
-      { title: 'Kolobox', image: koloboxImage, note: 'Яркая визуальная история для продукта с непростой первой реакцией аудитории.', href: 'https://drive.google.com/file/d/1eI5mODOu-mJ54QLPM_q0YuUP9bWjLN5k/view' },
-      { title: 'ЮРРОБОТ', image: yurrobotImage, note: 'Короткий ролик для узкой профессиональной аудитории.', href: 'https://drive.google.com/file/d/1bwItNtWXY-IfIrG910jVYGbsOH9BJukR/view' },
-      { title: 'АгроТех', image: agrotechImage, note: 'История, в которой технологичная отрасль становится живым миром будущего.' },
-      { title: 'ТПЭС', image: tpesImage, note: 'Промышленный B2B: объяснить реактивные потери быстрее 50 слайдов.', href: '/cases/tpes/' },
-      { title: 'Эндаумент-фонд МФТИ', image: mftiImage, note: 'Анимационная система, которая стала самостоятельным инфоповодом.', href: '/cases/mfti-endowment/' },
-      { title: 'Clappy', image: clappyImage, note: 'Explainer для продукта, который раньше приходилось долго объяснять.', href: '/cases/clappy/' },
+      {
+        title: 'Factory Director',
+        image: factoryDirectorImage,
+        note: 'Маскот и конференционный ролик для сложного B2B-продукта.',
+      },
+      {
+        title: 'Стартех',
+        image: startechImage,
+        note: 'Переупаковка продукта и объясняющий ролик для регионального B2B.',
+      },
+      {
+        title: 'Kolobox',
+        image: koloboxImage,
+        note: 'Яркая визуальная история для продукта с непростой первой реакцией аудитории.',
+        href: 'https://drive.google.com/file/d/1eI5mODOu-mJ54QLPM_q0YuUP9bWjLN5k/view',
+      },
+      {
+        title: 'ЮРРОБОТ',
+        image: yurrobotImage,
+        note: 'Короткий ролик для узкой профессиональной аудитории.',
+        href: 'https://drive.google.com/file/d/1bwItNtWXY-IfIrG910jVYGbsOH9BJukR/view',
+      },
+      {
+        title: 'АгроТех',
+        image: agrotechImage,
+        note: 'История, в которой технологичная отрасль становится живым миром будущего.',
+      },
+      {
+        title: 'ТПЭС',
+        image: tpesImage,
+        note: 'Промышленный B2B: объяснить реактивные потери быстрее 50 слайдов.',
+        href: '/cases/tpes/',
+      },
+      {
+        title: 'Эндаумент-фонд МФТИ',
+        image: mftiImage,
+        note: 'Анимационная система, которая стала самостоятельным инфоповодом.',
+        href: '/cases/mfti-endowment/',
+      },
+      {
+        title: 'Clappy',
+        image: clappyImage,
+        note: 'Explainer для продукта, который раньше приходилось долго объяснять.',
+        href: '/cases/clappy/',
+      },
     ],
   },
   '/cases/medicine': {
-    eyebrow: 'Pharma / MedTech', title: 'Pharma, MedTech и медицина',
-    description: 'Проекты, где одновременно важны точность, доверие и внимание: медицинские продукты, препараты, доказательная база, врачи и пациенты.', icon: Stethoscope,
+    eyebrow: 'Pharma / MedTech',
+    title: 'Pharma, MedTech и медицина',
+    description:
+      'Проекты, где одновременно важны точность, доверие и внимание: медицинские продукты, препараты, доказательная база, врачи и пациенты.',
+    icon: Stethoscope,
     cases: [
-      { title: 'Hemotech AI', image: hemotechImage, note: 'Спокойная визуальная система для инновационного MedTech-продукта.', href: '/cases/hemotech-ai/' },
-      { title: 'Мосфарма', image: mosfarmaImage, note: 'ТВ-ролик с бренд-персонажами и требованиями федерального эфира.', href: '/cases/mosfarma/' },
-      { title: 'Авиандр', placeholder: 'А', note: 'Медицинская анимация, доказательная база, маскоты и визуальная система препарата.', href: '/cases/aviandr/' },
+      {
+        title: 'Hemotech AI',
+        image: hemotechImage,
+        note: 'Спокойная визуальная система для инновационного MedTech-продукта.',
+        href: '/cases/hemotech-ai/',
+      },
+      {
+        title: 'Мосфарма',
+        image: mosfarmaImage,
+        note: 'ТВ-ролик с бренд-персонажами и требованиями федерального эфира.',
+        href: '/cases/mosfarma/',
+      },
+      {
+        title: 'Авиандр',
+        image: aviandrCoverImage,
+        note: 'Медицинская анимация, доказательная база, маскоты и визуальная система препарата.',
+        href: '/cases/aviandr/',
+      },
     ],
   },
   '/cases/cinema': {
-    eyebrow: 'Cinema / Creative', title: 'Cinema & Creative',
-    description: 'Кинематографичные прототипы, исторические миры и авторские эксперименты — там, где важны атмосфера, художественный язык и скорость проверки идеи.', icon: Camera,
+    eyebrow: 'Cinema / Creative',
+    title: 'Cinema & Creative',
+    description:
+      'Кинематографичные прототипы, исторические миры и авторские эксперименты — там, где важны атмосфера, художественный язык и скорость проверки идеи.',
+    icon: Camera,
     cases: [
-      { title: 'Маленький принц', image: littlePrinceImage, note: 'Имиджевый ролик-фантазия, собранный за один день.', href: '/cases/little-prince/' },
-      { title: 'Фёдор Бондарчук', image: bondarchukImage, note: 'Кинематографичный прототип сцены с нужной атмосферой за несколько часов.', href: 'https://drive.google.com/file/d/1wnRsoYIgio_MilkNFRlEBuTfgJfzx25d/view' },
-      { title: 'Бородино', image: borodinoImage, note: 'Исторический ролик с вниманием к форме, оружию, среде и масштабу.', href: '/cases/borodino/' },
+      {
+        title: 'Маленький принц',
+        image: littlePrinceImage,
+        note: 'Имиджевый ролик-фантазия, собранный за один день.',
+        href: '/cases/little-prince/',
+      },
+      {
+        title: 'Фёдор Бондарчук',
+        image: bondarchukImage,
+        note: 'Кинематографичный прототип сцены с нужной атмосферой за несколько часов.',
+        href: 'https://drive.google.com/file/d/1wnRsoYIgio_MilkNFRlEBuTfgJfzx25d/view',
+      },
+      {
+        title: 'Бородино',
+        image: borodinoImage,
+        note: 'Исторический ролик с вниманием к форме, оружию, среде и масштабу.',
+        href: '/cases/borodino/',
+      },
     ],
   },
   '/cases/hse': {
-    eyebrow: 'HSE / Safety', title: 'Охрана труда',
-    description: 'Визуальные системы, которые помогают правилам безопасности не растворяться в регламентах и оставаться в поле внимания сотрудников.', icon: HardHat,
-    cases: [{ title: 'Мултон Партнерс', image: multonImage, note: 'Маскот и визуальная система коммуникации жизненно важных правил.', href: '/cases/multon-partners/' }],
+    eyebrow: 'HSE / Safety',
+    title: 'Охрана труда',
+    description:
+      'Визуальные системы, которые помогают правилам безопасности не растворяться в регламентах и оставаться в поле внимания сотрудников.',
+    icon: HardHat,
+    cases: [
+      {
+        title: 'Мултон Партнерс',
+        image: multonImage,
+        note: 'Маскот и визуальная система коммуникации жизненно важных правил.',
+        href: '/cases/multon-partners/',
+      },
+    ],
   },
 };
 
 function CategoryCaseCard({ item }) {
-  const content = <><div className={`cases-hub-card__media${item.image ? '' : ' cases-hub-card__media--placeholder'}`}>{item.image ? <img src={item.image} alt={`Кейс Anix: ${item.title}`} loading="lazy" /> : <span>{item.placeholder}</span>}</div><div className="cases-hub-card__body"><h3>{item.title}</h3><p>{item.note}</p><span className="cases-hub-card__action">{item.href ? 'Смотреть кейс' : 'Страница кейса готовится'}{item.href ? <ArrowRight aria-hidden="true" /> : null}</span></div></>;
+  const content = (
+    <>
+      <div
+        className={`cases-hub-card__media${item.image ? '' : ' cases-hub-card__media--placeholder'}`}
+      >
+        {item.image ? (
+          <img src={item.image} alt={`Кейс Anix: ${item.title}`} loading="lazy" />
+        ) : (
+          <span>{item.placeholder}</span>
+        )}
+      </div>
+      <div className="cases-hub-card__body">
+        <h3>{item.title}</h3>
+        <p>{item.note}</p>
+        <span className="cases-hub-card__action">
+          {item.href ? 'Смотреть кейс' : 'Страница кейса готовится'}
+          {item.href ? <ArrowRight aria-hidden="true" /> : null}
+        </span>
+      </div>
+    </>
+  );
+
   if (!item.href) return <article className="cases-hub-card">{content}</article>;
+
   const external = /^https?:\/\//.test(item.href);
-  return <a className="cases-hub-card" href={item.href} target={external ? '_blank' : undefined} rel={external ? 'noreferrer' : undefined}>{content}</a>;
+  return (
+    <a
+      className="cases-hub-card"
+      href={item.href}
+      target={external ? '_blank' : undefined}
+      rel={external ? 'noreferrer' : undefined}
+    >
+      {content}
+    </a>
+  );
 }
 
 export default function CasesCategoryPage({ path }) {
   const category = categoryConfig[path];
   if (!category) return null;
+
   const Icon = category.icon;
-  return <main className="cases-hub-page cases-category-page">
-    <header className="cases-hub-header"><a href="/" className="cases-hub-logo" aria-label="Anix Studio — на главную"><BrandLogo alt="Anix Studio" width={120} height={44} /></a><a className="cases-hub-header__cta" href="https://t.me/anix_helper" target="_blank" rel="noreferrer">Обсудить проект</a></header>
-    <section className="cases-category-hero"><a className="cases-category-back" href="/cases/"><ArrowLeft aria-hidden="true" /> Все кейсы</a><div className="cases-hub-category__icon"><Icon aria-hidden="true" /></div><p className="cases-hub-eyebrow">{category.eyebrow}</p><h1>{category.title}</h1><p>{category.description}</p></section>
-    <section className="cases-hub-category cases-category-listing"><div className={`cases-hub-grid${category.cases.length === 1 ? ' cases-hub-grid--single' : ''}`}>{category.cases.map((item) => <CategoryCaseCard item={item} key={item.title} />)}</div></section>
-    <section className="cases-hub-cta"><p className="cases-hub-eyebrow">Другие задачи</p><h2>Посмотреть все направления и кейсы Anix</h2><a href="/cases/">Открыть все кейсы <ArrowRight aria-hidden="true" /></a></section>
-    <SiteFooter />
-  </main>;
+  return (
+    <main className="cases-hub-page cases-category-page">
+      <header className="cases-hub-header">
+        <a href="/" className="cases-hub-logo" aria-label="Anix Studio — на главную">
+          <BrandLogo alt="Anix Studio" width={120} height={44} />
+        </a>
+        <a
+          className="cases-hub-header__cta"
+          href="https://t.me/anix_helper"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Обсудить проект
+        </a>
+      </header>
+      <section className="cases-category-hero">
+        <a className="cases-category-back" href="/cases/">
+          <ArrowLeft aria-hidden="true" /> Все кейсы
+        </a>
+        <div className="cases-hub-category__icon">
+          <Icon aria-hidden="true" />
+        </div>
+        <p className="cases-hub-eyebrow">{category.eyebrow}</p>
+        <h1>{category.title}</h1>
+        <p>{category.description}</p>
+      </section>
+      <section className="cases-hub-category cases-category-listing">
+        <div
+          className={`cases-hub-grid${
+            category.cases.length === 1 ? ' cases-hub-grid--single' : ''
+          }`}
+        >
+          {category.cases.map((item) => (
+            <CategoryCaseCard item={item} key={item.title} />
+          ))}
+        </div>
+      </section>
+      <section className="cases-hub-cta">
+        <p className="cases-hub-eyebrow">Другие задачи</p>
+        <h2>Посмотреть все направления и кейсы Anix</h2>
+        <a href="/cases/">
+          Открыть все кейсы <ArrowRight aria-hidden="true" />
+        </a>
+      </section>
+      <SiteFooter />
+    </main>
+  );
 }

--- a/src/components/CasesHubPage.jsx
+++ b/src/components/CasesHubPage.jsx
@@ -3,6 +3,7 @@ import { ArrowRight, Camera, HardHat, Sparkles, Stethoscope, Workflow } from 'lu
 import BrandLogo from './BrandLogo';
 import SiteFooter from './SiteFooter';
 import agrotechImage from '../images/cases/agrotech.webp';
+import aviandrCoverImage from '../images/cases/aviandr-cover.webp';
 import bondarchukImage from '../images/cases/bondarchuk.webp';
 import borodinoImage from '../images/cases/borodino.webp';
 import clappyImage from '../images/cases/clappy.webp';
@@ -19,37 +20,268 @@ import yurrobotImage from '../images/cases/yurrobot.webp';
 import './CasesHubPage.css';
 
 const categories = [
-  { id: 'b2b', eyebrow: 'B2B / Technology', title: 'Технологии, B2B и сложные продукты', description: 'Когда продукт сложно объяснить одним слайдом: превращаем механику, пользу и контекст в историю, которую быстрее понимают клиенты, партнёры и инвесторы.', icon: Workflow, cases: [
-    { title: 'Factory Director', image: factoryDirectorImage, note: 'Маскот и конференционный ролик для сложного B2B-продукта.', href: null },
-    { title: 'Стартех', image: startechImage, note: 'Переупаковка продукта и объясняющий ролик для регионального B2B.', href: null },
-    { title: 'Kolobox', image: koloboxImage, note: 'Яркая визуальная история для продукта с непростой первой реакцией аудитории.', href: 'https://drive.google.com/file/d/1eI5mODOu-mJ54QLPM_q0YuUP9bWjLN5k/view' },
-    { title: 'ЮРРОБОТ', image: yurrobotImage, note: 'Короткий ролик для узкой профессиональной аудитории.', href: 'https://drive.google.com/file/d/1bwItNtWXY-IfIrG910jVYGbsOH9BJukR/view' },
-    { title: 'АгроТех', image: agrotechImage, note: 'История, в которой технологичная отрасль становится живым миром будущего.', href: null },
-    { title: 'ТПЭС', image: tpesImage, note: 'Промышленный B2B: объяснить реактивные потери быстрее 50 слайдов.', href: '/cases/tpes/' },
-    { title: 'Эндаумент-фонд МФТИ', image: mftiImage, note: 'Анимационная система, которая стала самостоятельным инфоповодом.', href: '/cases/mfti-endowment/' },
-    { title: 'Clappy', image: clappyImage, note: 'Explainer для продукта, который раньше приходилось долго объяснять.', href: '/cases/clappy/' },
-  ] },
-  { id: 'medicine', eyebrow: 'Pharma / MedTech', title: 'Pharma, MedTech и медицина', description: 'Работаем там, где одновременно важны точность, доверие и внимание: медицинские продукты, препараты, научная логика, врачи и пациенты.', icon: Stethoscope, cases: [
-    { title: 'Hemotech AI', image: hemotechImage, note: 'Спокойная визуальная система для инновационного MedTech-продукта.', href: '/cases/hemotech-ai/' },
-    { title: 'Мосфарма', image: mosfarmaImage, note: 'ТВ-ролик с бренд-персонажами и требованиями федерального эфира.', href: '/cases/mosfarma/' },
-    { title: 'Авиандр', image: null, note: 'Медицинская анимация, доказательная база, маскоты и визуальная система препарата.', href: '/cases/aviandr/', placeholder: 'А' },
-  ] },
-  { id: 'cinema', eyebrow: 'Cinema / Creative', title: 'Cinema & Creative', description: 'Кинематографичные прототипы, исторические миры и авторские эксперименты — там, где важны атмосфера, художественный язык и скорость проверки идеи.', icon: Camera, cases: [
-    { title: 'Очень сладкий кейс', image: null, note: 'AI внутри анимационного production: консистентность персонажей, рецептурная сцена и чистое движение.', href: '/cases/very-sweet-case/', placeholder: '🍮' },
-    { title: 'Маленький принц', image: littlePrinceImage, note: 'Имиджевый ролик-фантазия, собранный за один день.', href: '/cases/little-prince/' },
-    { title: 'Фёдор Бондарчук', image: bondarchukImage, note: 'Кинематографичный прототип сцены с нужной атмосферой за несколько часов.', href: 'https://drive.google.com/file/d/1wnRsoYIgio_MilkNFRlEBuTfgJfzx25d/view' },
-    { title: 'Бородино', image: borodinoImage, note: 'Исторический ролик с вниманием к форме, оружию, среде и масштабу.', href: '/cases/borodino/' },
-  ] },
-  { id: 'hse', eyebrow: 'HSE / Safety', title: 'Охрана труда', description: 'Визуальные системы, которые помогают правилам безопасности не растворяться в регламентах и действительно оставаться в поле внимания сотрудников.', icon: HardHat, cases: [{ title: 'Мултон Партнерс', image: multonImage, note: 'Маскот и визуальная система коммуникации жизненно важных правил.', href: '/cases/multon-partners/', featured: true }] },
+  {
+    id: 'b2b',
+    eyebrow: 'B2B / Technology',
+    title: 'Технологии, B2B и сложные продукты',
+    description:
+      'Когда продукт сложно объяснить одним слайдом: превращаем механику, пользу и контекст в историю, которую быстрее понимают клиенты, партнёры и инвесторы.',
+    icon: Workflow,
+    cases: [
+      {
+        title: 'Factory Director',
+        image: factoryDirectorImage,
+        note: 'Маскот и конференционный ролик для сложного B2B-продукта.',
+        href: null,
+      },
+      {
+        title: 'Стартех',
+        image: startechImage,
+        note: 'Переупаковка продукта и объясняющий ролик для регионального B2B.',
+        href: null,
+      },
+      {
+        title: 'Kolobox',
+        image: koloboxImage,
+        note: 'Яркая визуальная история для продукта с непростой первой реакцией аудитории.',
+        href: 'https://drive.google.com/file/d/1eI5mODOu-mJ54QLPM_q0YuUP9bWjLN5k/view',
+      },
+      {
+        title: 'ЮРРОБОТ',
+        image: yurrobotImage,
+        note: 'Короткий ролик для узкой профессиональной аудитории.',
+        href: 'https://drive.google.com/file/d/1bwItNtWXY-IfIrG910jVYGbsOH9BJukR/view',
+      },
+      {
+        title: 'АгроТех',
+        image: agrotechImage,
+        note: 'История, в которой технологичная отрасль становится живым миром будущего.',
+        href: null,
+      },
+      {
+        title: 'ТПЭС',
+        image: tpesImage,
+        note: 'Промышленный B2B: объяснить реактивные потери быстрее 50 слайдов.',
+        href: '/cases/tpes/',
+      },
+      {
+        title: 'Эндаумент-фонд МФТИ',
+        image: mftiImage,
+        note: 'Анимационная система, которая стала самостоятельным инфоповодом.',
+        href: '/cases/mfti-endowment/',
+      },
+      {
+        title: 'Clappy',
+        image: clappyImage,
+        note: 'Explainer для продукта, который раньше приходилось долго объяснять.',
+        href: '/cases/clappy/',
+      },
+    ],
+  },
+  {
+    id: 'medicine',
+    eyebrow: 'Pharma / MedTech',
+    title: 'Pharma, MedTech и медицина',
+    description:
+      'Работаем там, где одновременно важны точность, доверие и внимание: медицинские продукты, препараты, научная логика, врачи и пациенты.',
+    icon: Stethoscope,
+    cases: [
+      {
+        title: 'Hemotech AI',
+        image: hemotechImage,
+        note: 'Спокойная визуальная система для инновационного MedTech-продукта.',
+        href: '/cases/hemotech-ai/',
+      },
+      {
+        title: 'Мосфарма',
+        image: mosfarmaImage,
+        note: 'ТВ-ролик с бренд-персонажами и требованиями федерального эфира.',
+        href: '/cases/mosfarma/',
+      },
+      {
+        title: 'Авиандр',
+        image: aviandrCoverImage,
+        note: 'Медицинская анимация, доказательная база, маскоты и визуальная система препарата.',
+        href: '/cases/aviandr/',
+      },
+    ],
+  },
+  {
+    id: 'cinema',
+    eyebrow: 'Cinema / Creative',
+    title: 'Cinema & Creative',
+    description:
+      'Кинематографичные прототипы, исторические миры и авторские эксперименты — там, где важны атмосфера, художественный язык и скорость проверки идеи.',
+    icon: Camera,
+    cases: [
+      {
+        title: 'Очень сладкий кейс',
+        image: null,
+        note: 'AI внутри анимационного production: консистентность персонажей, рецептурная сцена и чистое движение.',
+        href: '/cases/very-sweet-case/',
+        placeholder: '🍮',
+      },
+      {
+        title: 'Маленький принц',
+        image: littlePrinceImage,
+        note: 'Имиджевый ролик-фантазия, собранный за один день.',
+        href: '/cases/little-prince/',
+      },
+      {
+        title: 'Фёдор Бондарчук',
+        image: bondarchukImage,
+        note: 'Кинематографичный прототип сцены с нужной атмосферой за несколько часов.',
+        href: 'https://drive.google.com/file/d/1wnRsoYIgio_MilkNFRlEBuTfgJfzx25d/view',
+      },
+      {
+        title: 'Бородино',
+        image: borodinoImage,
+        note: 'Исторический ролик с вниманием к форме, оружию, среде и масштабу.',
+        href: '/cases/borodino/',
+      },
+    ],
+  },
+  {
+    id: 'hse',
+    eyebrow: 'HSE / Safety',
+    title: 'Охрана труда',
+    description:
+      'Визуальные системы, которые помогают правилам безопасности не растворяться в регламентах и действительно оставаться в поле внимания сотрудников.',
+    icon: HardHat,
+    cases: [
+      {
+        title: 'Мултон Партнерс',
+        image: multonImage,
+        note: 'Маскот и визуальная система коммуникации жизненно важных правил.',
+        href: '/cases/multon-partners/',
+        featured: true,
+      },
+    ],
+  },
 ];
 
 function CaseCard({ item }) {
-  const content = <><div className={`cases-hub-card__media${item.image ? '' : ' cases-hub-card__media--placeholder'}`}>{item.image ? <img src={item.image} alt={`Кейс Anix: ${item.title}`} loading="lazy" /> : <span>{item.placeholder}</span>}</div><div className="cases-hub-card__body"><h3>{item.title}</h3><p>{item.note}</p><span className="cases-hub-card__action">{item.href ? 'Смотреть кейс' : 'Страница кейса готовится'}{item.href ? <ArrowRight aria-hidden="true" /> : null}</span></div></>;
-  if (!item.href) return <article className={`cases-hub-card${item.featured ? ' cases-hub-card--featured' : ''}`}>{content}</article>;
+  const content = (
+    <>
+      <div
+        className={`cases-hub-card__media${item.image ? '' : ' cases-hub-card__media--placeholder'}`}
+      >
+        {item.image ? (
+          <img src={item.image} alt={`Кейс Anix: ${item.title}`} loading="lazy" />
+        ) : (
+          <span>{item.placeholder}</span>
+        )}
+      </div>
+      <div className="cases-hub-card__body">
+        <h3>{item.title}</h3>
+        <p>{item.note}</p>
+        <span className="cases-hub-card__action">
+          {item.href ? 'Смотреть кейс' : 'Страница кейса готовится'}
+          {item.href ? <ArrowRight aria-hidden="true" /> : null}
+        </span>
+      </div>
+    </>
+  );
+
+  if (!item.href) {
+    return (
+      <article className={`cases-hub-card${item.featured ? ' cases-hub-card--featured' : ''}`}>
+        {content}
+      </article>
+    );
+  }
+
   const external = /^https?:\/\//.test(item.href);
-  return <a className={`cases-hub-card${item.featured ? ' cases-hub-card--featured' : ''}`} href={item.href} target={external ? '_blank' : undefined} rel={external ? 'noreferrer' : undefined}>{content}</a>;
+  return (
+    <a
+      className={`cases-hub-card${item.featured ? ' cases-hub-card--featured' : ''}`}
+      href={item.href}
+      target={external ? '_blank' : undefined}
+      rel={external ? 'noreferrer' : undefined}
+    >
+      {content}
+    </a>
+  );
 }
 
 export default function CasesHubPage() {
-  return <main className="cases-hub-page"><header className="cases-hub-header"><a href="/" className="cases-hub-logo" aria-label="Anix Studio — на главную"><BrandLogo alt="Anix Studio" width={120} height={44} /></a><a className="cases-hub-header__cta" href="https://t.me/anix_helper" target="_blank" rel="noreferrer">Обсудить проект</a></header><section className="cases-hub-hero"><p className="cases-hub-eyebrow">Кейсы Anix Studio</p><h1>Сложные продукты, которые стали понятными историями</h1><p>Здесь собраны проекты для технологий, B2B, фармы, MedTech, кино и охраны труда.</p><nav className="cases-hub-jump" aria-label="Категории кейсов">{categories.map((category) => <a href={`/cases/${category.id}/`} key={category.id}>{category.title}</a>)}<a href="#events">Events</a></nav></section>{categories.map((category) => { const Icon = category.icon; return <section className="cases-hub-category" id={category.id} key={category.id}><div className="cases-hub-category__head"><div className="cases-hub-category__icon"><Icon aria-hidden="true" /></div><div><p className="cases-hub-eyebrow">{category.eyebrow}</p><h2>{category.title}</h2><p>{category.description}</p><a href={`/cases/${category.id}/`}>Открыть категорию <ArrowRight aria-hidden="true" /></a></div></div><div className={`cases-hub-grid${category.cases.length === 1 ? ' cases-hub-grid--single' : ''}`}>{category.cases.map((item) => <CaseCard item={item} key={item.title} />)}</div></section>; })}<section className="cases-hub-events" id="events"><div className="cases-hub-events__icon"><Sparkles aria-hidden="true" /></div><p className="cases-hub-eyebrow">Events</p><h2>Скоро</h2><p>Добавим проекты с экранным контентом, AI-визуалами и режиссурой событий.</p></section><section className="cases-hub-cta"><p className="cases-hub-eyebrow">Новая задача</p><h2>Не нашли кейс ровно из вашей отрасли?</h2><p>Покажите продукт или идею. Разберёмся в задаче и предложим формат, который имеет смысл именно для неё.</p><a href="https://t.me/anix_helper" target="_blank" rel="noreferrer">Обсудить проект <ArrowRight aria-hidden="true" /></a></section><SiteFooter /></main>;
+  return (
+    <main className="cases-hub-page">
+      <header className="cases-hub-header">
+        <a href="/" className="cases-hub-logo" aria-label="Anix Studio — на главную">
+          <BrandLogo alt="Anix Studio" width={120} height={44} />
+        </a>
+        <a
+          className="cases-hub-header__cta"
+          href="https://t.me/anix_helper"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Обсудить проект
+        </a>
+      </header>
+      <section className="cases-hub-hero">
+        <p className="cases-hub-eyebrow">Кейсы Anix Studio</p>
+        <h1>Сложные продукты, которые стали понятными историями</h1>
+        <p>Здесь собраны проекты для технологий, B2B, фармы, MedTech, кино и охраны труда.</p>
+        <nav className="cases-hub-jump" aria-label="Категории кейсов">
+          {categories.map((category) => (
+            <a href={`/cases/${category.id}/`} key={category.id}>
+              {category.title}
+            </a>
+          ))}
+          <a href="#events">Events</a>
+        </nav>
+      </section>
+      {categories.map((category) => {
+        const Icon = category.icon;
+        return (
+          <section className="cases-hub-category" id={category.id} key={category.id}>
+            <div className="cases-hub-category__head">
+              <div className="cases-hub-category__icon">
+                <Icon aria-hidden="true" />
+              </div>
+              <div>
+                <p className="cases-hub-eyebrow">{category.eyebrow}</p>
+                <h2>{category.title}</h2>
+                <p>{category.description}</p>
+                <a href={`/cases/${category.id}/`}>
+                  Открыть категорию <ArrowRight aria-hidden="true" />
+                </a>
+              </div>
+            </div>
+            <div
+              className={`cases-hub-grid${
+                category.cases.length === 1 ? ' cases-hub-grid--single' : ''
+              }`}
+            >
+              {category.cases.map((item) => (
+                <CaseCard item={item} key={item.title} />
+              ))}
+            </div>
+          </section>
+        );
+      })}
+      <section className="cases-hub-events" id="events">
+        <div className="cases-hub-events__icon">
+          <Sparkles aria-hidden="true" />
+        </div>
+        <p className="cases-hub-eyebrow">Events</p>
+        <h2>Скоро</h2>
+        <p>Добавим проекты с экранным контентом, AI-визуалами и режиссурой событий.</p>
+      </section>
+      <section className="cases-hub-cta">
+        <p className="cases-hub-eyebrow">Новая задача</p>
+        <h2>Не нашли кейс ровно из вашей отрасли?</h2>
+        <p>
+          Покажите продукт или идею. Разберёмся в задаче и предложим формат, который имеет смысл
+          именно для неё.
+        </p>
+        <a href="https://t.me/anix_helper" target="_blank" rel="noreferrer">
+          Обсудить проект <ArrowRight aria-hidden="true" />
+        </a>
+      </section>
+      <SiteFooter />
+    </main>
+  );
 }


### PR DESCRIPTION
Uses the committed `src/images/cases/aviandr-cover.webp` and `aviandr-koala.webp` assets everywhere they are needed: the dedicated Aviandr case hero, mascot section, both VK video posters, the cases hub, the medicine category, static SEO shell and social preview output. The build copies the source cover to a stable public URL without introducing a second source-of-truth in the repository.