### PR TITLE
Match case pages to the homepage wide grid

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import React, { lazy, Suspense } from 'react';
 import { CONFIG } from '@/config';
 import ReactDOM from 'react-dom/client';
 import './App.css';
+import './styles/case-wide-layout.css';
 import App from './App';
 import AppLayout from './AppLayout';
 import AboutStudioPortal from './components/AboutStudioPortal';

--- a/src/styles/case-wide-layout.css
+++ b/src/styles/case-wide-layout.css
@@ -1,0 +1,51 @@
+/* Keep all case-related pages on the same wide desktop grid as the homepage. */
+
+@media (min-width: 641px) {
+  .cases-hub-page .cases-hub-hero,
+  .cases-hub-page .cases-hub-category,
+  .cases-hub-page .cases-hub-events,
+  .cases-hub-page .cases-hub-cta {
+    width: calc(100% - clamp(48px, 6vw, 144px));
+    max-width: none;
+  }
+}
+
+@media (min-width: 681px) {
+  .aviandr-case-page .aviandr-header,
+  .sweet-case-page .sweet-header {
+    width: calc(100% - clamp(32px, 5vw, 96px));
+    max-width: none;
+  }
+
+  .aviandr-case-page .aviandr-hero,
+  .aviandr-case-page .aviandr-section,
+  .aviandr-case-page .aviandr-result,
+  .aviandr-case-page .aviandr-cta,
+  .sweet-case-page .sweet-hero,
+  .sweet-case-page .sweet-section:not(.sweet-dark),
+  .sweet-case-page .sweet-note,
+  .sweet-case-page .sweet-final-cta {
+    width: calc(100% - clamp(48px, 6vw, 144px));
+    max-width: none;
+  }
+
+  .sweet-case-page .sweet-dark {
+    width: 100%;
+    max-width: none;
+    padding-inline: clamp(24px, 3vw, 72px);
+  }
+}
+
+@media (min-width: 861px) {
+  .case-page .case-header {
+    width: calc(100% - clamp(32px, 5vw, 96px));
+    max-width: none;
+  }
+
+  .case-page .case-hero,
+  .case-page .case-story,
+  .case-page .case-related {
+    width: calc(100% - clamp(48px, 6vw, 144px));
+    max-width: none;
+  }
+}


### PR DESCRIPTION
Removes the desktop max-width bottleneck from the cases hub, case categories, generic case pages, the Aviandr case and the Very Sweet Case. Desktop gutters now match the homepage grid while existing mobile widths remain unchanged.