### PR TITLE
Hide Андрей profile from navigation and indexing

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "node scripts/ensure-andrey-profile-discoverability.js && node scripts/ensure-andrey-profile-route.js && node scripts/ensure-cases-hub-route.js && node scripts/ensure-animation-route.js && node scripts/ensure-ai-video-route.js && node scripts/ensure-very-sweet-case-route.js && node scripts/ensure-aviandr-case-route.js && node scripts/generate-rybki-page-data.js && node scripts/optimize-assets.js && node scripts/generate-seo-assets.js && node scripts/prepare-seo-source.js && node scripts/build.js",
-    "postbuild": "node scripts/create-static-routes.js && node scripts/generate-static-seo.js && node scripts/inject-approved-brand-line.js && node scripts/normalize-seo-output.js && node scripts/verify-seo-build.js",
+    "postbuild": "node scripts/create-static-routes.js && node scripts/generate-static-seo.js && node scripts/inject-approved-brand-line.js && node scripts/normalize-seo-output.js && node scripts/verify-andrey-profile-hidden.js && node scripts/verify-seo-build.js",
     "seo:verify": "node scripts/verify-seo-build.js && node scripts/verify-brand-seo.js",
     "optimize:assets": "node scripts/optimize-assets.js",
     "test": "react-scripts test",

--- a/scripts/ensure-andrey-profile-discoverability.js
+++ b/scripts/ensure-andrey-profile-discoverability.js
@@ -4,7 +4,6 @@ const path = require('path');
 const root = path.resolve(__dirname, '..');
 const profilePath = path.join(root, 'src', 'components', 'AndreyProfilePage.jsx');
 const profileCssPath = path.join(root, 'src', 'components', 'AndreyProfilePage.css');
-const homePath = path.join(root, 'src', 'components', 'Design1TestPage.jsx');
 
 function replaceOnce(content, search, replacement, label) {
   if (content.includes(replacement)) return content;
@@ -36,13 +35,4 @@ profileCss = replaceOnce(
 );
 fs.writeFileSync(profileCssPath, profileCss);
 
-let home = fs.readFileSync(homePath, 'utf8');
-home = replaceOnce(
-  home,
-  "  { label: 'CEO', href: '/ceo' },\n  { label: 'Процесс', href: '#process' },",
-  "  { label: 'CEO', href: '/ceo' },\n  { label: 'Андрей', href: '/andrey-tsarev' },\n  { label: 'Процесс', href: '#process' },",
-  'homepage navigation',
-);
-fs.writeFileSync(homePath, home);
-
-console.log('[andrey-discoverability] gallery and homepage navigation are ready');
+console.log('[andrey-discoverability] profile gallery is ready without public navigation links');

--- a/scripts/ensure-andrey-profile-route.js
+++ b/scripts/ensure-andrey-profile-route.js
@@ -80,6 +80,10 @@ async function main() {
       "name: 'Александра Севостьянова',\n        jobTitle: 'CEO Anix Studio',",
       "name: route.person?.name || 'Александра Севостьянова',\n        jobTitle: route.person?.jobTitle || 'CEO Anix Studio',\n        ...(route.person?.sameAs ? { sameAs: route.person.sameAs } : {}),",
     );
+    source = source.replace(
+      "const robots = route.indexable ? 'index, follow' : 'noindex, follow';",
+      "const robots = route.robots || (route.indexable ? 'index, follow' : 'noindex, follow');",
+    );
     fs.writeFileSync(filePath, source);
   }
 

--- a/scripts/ensure-andrey-profile-route.js
+++ b/scripts/ensure-andrey-profile-route.js
@@ -33,7 +33,8 @@ async function main() {
 
   const seo = JSON.parse(fs.readFileSync(routesPath, 'utf8'));
   seo.routes['/andrey-tsarev'] = {
-    indexable: true,
+    indexable: false,
+    robots: 'noindex, nofollow',
     kind: 'profile',
     title: 'Андрей Царёв — сооснователь и продуктовый директор Anix Studio',
     description: 'Андрей Царёв — предприниматель, сооснователь Anix Studio, режиссёр, сценарист и биофизик. Продукты, творчество, технологии, научная работа и подход к сложным проектам.',
@@ -87,7 +88,7 @@ async function main() {
   fs.mkdirSync(path.dirname(ogTarget), { recursive: true });
   await sharp(ogSource).resize(1200, 630, { fit: 'cover', position: 'attention' }).jpeg({ quality: 88, progressive: true }).toFile(ogTarget);
 
-  console.log('[andrey-profile] route, SEO and OG asset are ready');
+  console.log('[andrey-profile] direct route is ready and hidden from indexing');
 }
 
 main().catch((error) => {

--- a/scripts/verify-andrey-profile-hidden.js
+++ b/scripts/verify-andrey-profile-hidden.js
@@ -1,0 +1,59 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const buildDir = path.join(root, 'build');
+const profileFile = path.join(buildDir, 'andrey-tsarev', 'index.html');
+const sitemapFile = path.join(buildDir, 'sitemap.xml');
+const profileReference = '/andrey-tsarev';
+const failures = [];
+
+function collectHtmlFiles(directory) {
+  const files = [];
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const filePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...collectHtmlFiles(filePath));
+    else if (entry.isFile() && entry.name.endsWith('.html')) files.push(filePath);
+  }
+  return files;
+}
+
+function assert(condition, message) {
+  if (!condition) failures.push(message);
+}
+
+assert(fs.existsSync(profileFile), 'Direct Андрей profile HTML is missing');
+
+if (fs.existsSync(profileFile)) {
+  const profileHtml = fs.readFileSync(profileFile, 'utf8');
+  assert(
+    /<meta\s+name="robots"\s+content="noindex, nofollow"\s*\/?\s*>/i.test(profileHtml),
+    'Андрей profile must use noindex, nofollow',
+  );
+}
+
+if (fs.existsSync(buildDir)) {
+  for (const filePath of collectHtmlFiles(buildDir)) {
+    if (path.resolve(filePath) === path.resolve(profileFile)) continue;
+    const html = fs.readFileSync(filePath, 'utf8');
+    if (html.includes(profileReference)) {
+      failures.push(`Public profile reference found in ${path.relative(root, filePath)}`);
+    }
+  }
+} else {
+  failures.push('build directory is missing');
+}
+
+assert(fs.existsSync(sitemapFile), 'sitemap.xml is missing');
+if (fs.existsSync(sitemapFile)) {
+  const sitemap = fs.readFileSync(sitemapFile, 'utf8');
+  assert(!sitemap.includes('andrey-tsarev'), 'Андрей profile must not be included in sitemap.xml');
+}
+
+if (failures.length) {
+  console.error('\nАндрей profile visibility verification failed:');
+  for (const failure of failures) console.error(` - ${failure}`);
+  process.exit(1);
+}
+
+console.log('[andrey-hidden] direct page kept; noindex/nofollow, sitemap exclusion and zero inbound HTML links verified');


### PR DESCRIPTION
## Что изменено

- build-time скрипт больше не добавляет ссылку «Андрей» в навигацию главной;
- прямой маршрут `/andrey-tsarev/` сохранён;
- SEO-конфигурация страницы переведена в `indexable: false`;
- для страницы задано точное правило `noindex, nofollow` как в статическом HTML, так и после загрузки React;
- страница автоматически исключается из `sitemap.xml`;
- добавлена финальная build-проверка: строка `/andrey-tsarev` не может встречаться ни в одном HTML-файле, кроме собственного HTML страницы;
- проверка отдельно подтверждает отсутствие страницы в sitemap и наличие `noindex, nofollow`.

## Почему

Страница Андрея пока ремонтируется. Её прямой URL нужен для параллельной проверки, но она не должна продвигаться через навигацию, внутреннюю перелинковку или поисковую индексацию.

Корневая причина публичной ссылки была в `ensure-andrey-profile-discoverability.js`: скрипт заново добавлял пункт навигации при каждой production-сборке, поэтому исправление только React-компонента было бы нестабильным.

## Что не менялось

- содержимое страницы Андрея;
- фотографии и их вёрстка;
- остальные страницы и их тексты;
- маршрут `/andrey-tsarev/`.

## Проверка

CI должен выполнить полный quality pipeline и production build. Новый postbuild assertion дополнительно проверит финальные HTML и sitemap.