### PR TITLE
Fix hero headline wrapping on compact laptops

### DIFF
--- a/src/Design1TestPage.css
+++ b/src/Design1TestPage.css
@@ -157,6 +157,7 @@
 
 .d1-hero-copy {
   max-width: 820px;
+  container-type: inline-size;
 }
 
 .d1-eyebrow {
@@ -179,9 +180,17 @@
 
 .d1-hero h1 {
   max-width: 930px;
-  font-size: clamp(64px, 8vw, 124px);
+  font-size: clamp(60px, 8vw, 124px);
+  font-size: clamp(60px, 15.5cqw, 124px);
   line-height: 0.9;
-  overflow-wrap: anywhere;
+  overflow-wrap: normal;
+  word-break: normal;
+  hyphens: none;
+}
+
+.d1-hero-title-line {
+  display: block;
+  white-space: nowrap;
 }
 
 .d1-lead {

--- a/src/components/Design1TestPage.jsx
+++ b/src/components/Design1TestPage.jsx
@@ -503,7 +503,11 @@ function Design1TestPage() {
           <p className="d1-eyebrow">
             Anix Studio (Студия Аникс) — анимационная студия для сложных продуктов.
           </p>
-          <h1>Делаем сложное интересным</h1>
+          <h1 className="d1-hero-title">
+            <span className="d1-hero-title-line">Делаем</span>
+            <span className="d1-hero-title-line">сложное</span>
+            <span className="d1-hero-title-line">интересным</span>
+          </h1>
                     <p className="d1-lead">
             Сначала понимание. Потом восхищение. Anix помогает вовлекать в
             сложные продукты, правила и идеи через 2D-анимацию, историю и ясную

--- a/src/components/Design1TestPage.jsx
+++ b/src/components/Design1TestPage.jsx
@@ -504,8 +504,8 @@ function Design1TestPage() {
             Anix Studio (Студия Аникс) — анимационная студия для сложных продуктов.
           </p>
           <h1 className="d1-hero-title">
-            <span className="d1-hero-title-line">Делаем</span>
-            <span className="d1-hero-title-line">сложное</span>
+            <span className="d1-hero-title-line">Делаем </span>
+            <span className="d1-hero-title-line">сложное </span>
             <span className="d1-hero-title-line">интересным</span>
           </h1>
                     <p className="d1-lead">


### PR DESCRIPTION
## Что изменено

- Заголовок «Делаем сложное интересным» разбит на три управляемые строки.
- Каждое слово защищено от переноса внутри слова.
- Размер заголовка теперь зависит от фактической ширины текстовой колонки, а не только от ширины окна.

## Почему

На 13-дюймовом MacBook при ширине около 1180–1280 px браузер переносил «интересным» как «интересн/ым» или «интересны/м». Причина — сочетание `overflow-wrap: anywhere` и слишком крупного viewport-based шрифта в двухколоночном hero.

## Эффект

Первый экран сохраняет композицию с showreel справа, но заголовок стабильно выглядит как три целых слова на соседних desktop-ширинах и при изменении масштаба.

## Проверка

- Проверен минимальный diff: только hero JSX и его CSS.
- Ветка создана от актуального `main`.
- CI и production build должны подтвердить отсутствие регрессий.