### PR TITLE
Retry website lead production deployment

### DIFF
--- a/supabase/functions/submit-website-lead/index.ts
+++ b/supabase/functions/submit-website-lead/index.ts
@@ -1,6 +1,8 @@
 declare const Deno: any;
 declare const process: any;
 
+// This public function is deployed by the Supabase Actions workflow.
+
 const DEFAULT_ORIGINS = [
   'https://studio.anix-ai.pro',
   'https://dev.studio.anix-ai.pro',


### PR DESCRIPTION
## What changed

Adds one deployment-only comment to `submit-website-lead`.

## Why

The original Supabase deployment was cancelled in the GitHub Actions outage. The production endpoint currently returns `404 Requested function was not found`. Merging this PR changes the function path again, which re-triggers the existing Supabase deployment workflow and also starts a fresh Pages deployment.

## Impact

No runtime behavior changes.

## Validation

- original PR #197 quality checks passed;
- current Supabase project is healthy;
- production function endpoint currently confirms the missing deployment with `NOT_FOUND`.