### PR TITLE
Keep production origin in website lead allowlist

### DIFF
--- a/src/__tests__/functions.test.js
+++ b/src/__tests__/functions.test.js
@@ -203,6 +203,7 @@ describe('submit-website-lead', () => {
     delete process.env.TURNSTILE_SECRET_KEY;
     delete process.env.SUPABASE_URL;
     delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    delete process.env.WEBSITE_LEAD_ALLOWED_ORIGINS;
   });
 
   const validBody = {
@@ -256,5 +257,30 @@ describe('submit-website-lead', () => {
     expect(res.status).toBe(400);
     expect((await res.json()).error).toBe('turnstile_failed');
     expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('keeps the production origin when custom origins are configured', async () => {
+    process.env.WEBSITE_LEAD_ALLOWED_ORIGINS = 'https://preview.example';
+    process.env.TURNSTILE_SECRET_KEY = 'turnstile-secret';
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ success: false }),
+      })
+    );
+    const submitWebsiteLead =
+      require('../../supabase/functions/submit-website-lead/index.js').default;
+    const req = new Request('https://example.com', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        origin: 'https://studio.anix-ai.pro',
+      },
+      body: JSON.stringify(validBody),
+    });
+    const res = await submitWebsiteLead(req);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('turnstile_failed');
   });
 });

--- a/supabase/functions/submit-website-lead/index.ts
+++ b/supabase/functions/submit-website-lead/index.ts
@@ -31,12 +31,13 @@ function env(name: string): string {
 
 function allowedOrigins(): string[] {
   const configured = env('WEBSITE_LEAD_ALLOWED_ORIGINS');
-  return configured
+  const extraOrigins = configured
     ? configured
         .split(',')
         .map((value) => value.trim())
         .filter(Boolean)
-    : DEFAULT_ORIGINS;
+    : [];
+  return [...new Set([...DEFAULT_ORIGINS, ...extraOrigins])];
 }
 
 function isAllowedOrigin(origin: string): boolean {


### PR DESCRIPTION
## Что изменено

- встроенные разрешённые домены формы всегда сохраняются;
- значения из `WEBSITE_LEAD_ALLOWED_ORIGINS` добавляются к ним, а не заменяют их;
- добавлен регрессионный тест для production-origin.

## Причина

После первого production-деплоя `submit-website-lead` отвечала `403 origin_not_allowed` на запросы с `https://studio.anix-ai.pro` из-за значения окружения, которое полностью заменяло безопасный список по умолчанию.

## Проверка

`npm test -- --runInBand src/__tests__/functions.test.js` — 6/6 тестов прошли.