### PR TITLE
Fix invisible text in lead success CTA

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom/client';
 import './App.css';
 import './styles/case-wide-layout.css';
 import './styles/site-wide-layout.css';
+import './styles/lead-form-overrides.css';
 import App from './App';
 import AppLayout from './AppLayout';
 import AboutStudioPortal from './components/AboutStudioPortal';

--- a/src/styles/lead-form-overrides.css
+++ b/src/styles/lead-form-overrides.css
@@ -1,0 +1,16 @@
+/* Cross-page guard for the website lead success CTA.
+   Some page shells (for example .design1-test a) set anchor color with
+   higher selector specificity than the component-local CTA rule. */
+.website-lead-modal a.website-lead-modal__cta {
+  color: #fff !important;
+  -webkit-text-fill-color: #fff !important;
+}
+
+.website-lead-modal a.website-lead-modal__cta svg {
+  color: #fff;
+  stroke: currentColor;
+}
+
+.website-lead-modal a.website-lead-modal__cta:hover {
+  background: #087d70;
+}


### PR DESCRIPTION
Исправляет невидимый текст кнопки в success-попапе формы. Причина: глобальный селектор `.design1-test a { color: inherit; }` имел большую специфичность и перебивал белый цвет текста CTA. Добавлен узкий cross-page override для CTA и иконки.