### PR TITLE
Add RCHK event production case

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "start": "node scripts/run-website-lead-consent-once.js && react-scripts start",
-    "build": "node scripts/run-website-lead-consent-once.js && node scripts/ensure-andrey-profile-discoverability.js && node scripts/ensure-andrey-profile-route.js && node scripts/ensure-cases-hub-route.js && node scripts/ensure-animation-route.js && node scripts/ensure-ai-video-route.js && node scripts/ensure-very-sweet-case-route.js && node scripts/ensure-aviandr-case-route.js && node scripts/generate-rybki-page-data.js && node scripts/optimize-assets.js && node scripts/generate-seo-assets.js && node scripts/prepare-seo-source.js && node scripts/build.js",
+    "build": "node scripts/run-website-lead-consent-once.js && node scripts/ensure-andrey-profile-discoverability.js && node scripts/ensure-andrey-profile-route.js && node scripts/ensure-cases-hub-route.js && node scripts/ensure-rchk-case-route.js && node scripts/ensure-animation-route.js && node scripts/ensure-ai-video-route.js && node scripts/ensure-very-sweet-case-route.js && node scripts/ensure-aviandr-case-route.js && node scripts/generate-rybki-page-data.js && node scripts/optimize-assets.js && node scripts/generate-seo-assets.js && node scripts/prepare-seo-source.js && node scripts/build.js",
     "postbuild": "node scripts/create-static-routes.js && node scripts/generate-static-seo.js && node scripts/inject-approved-brand-line.js && node scripts/normalize-seo-output.js && node scripts/verify-andrey-profile-hidden.js && node scripts/verify-andrey-profile-photos.js && node scripts/verify-seo-build.js",
     "seo:verify": "node scripts/verify-seo-build.js && node scripts/verify-brand-seo.js",
     "optimize:assets": "node scripts/optimize-assets.js",

--- a/scripts/create-static-routes.js
+++ b/scripts/create-static-routes.js
@@ -32,9 +32,9 @@ const lessonRoutes = [
 
 const routes = [
   'medicine','why_it_works','ceo','hse','animation','ai-video','rybki','rybki_page',
-  'cases','cases/b2b','cases/medicine','cases/cinema','cases/hse',
+  'cases','cases/b2b','cases/medicine','cases/cinema','cases/hse','cases/events',
   'cases/clappy','cases/hemotech-ai','cases/tpes','cases/mfti-endowment','cases/mosfarma','cases/multon-partners',
-  'cases/aviandr','cases/little-prince','cases/borodino',
+  'cases/aviandr','cases/little-prince','cases/borodino','cases/rchk',
   'hse/mvp','hse/mvp/showcase','hse/mvp/showcase/organization',
   ...departments.map((department) => `hse/mvp/showcase/departments/${department}`),
   ...modules.map((module) => `hse/mvp/showcase/modules/${module}`),

--- a/scripts/ensure-rchk-case-route.js
+++ b/scripts/ensure-rchk-case-route.js
@@ -1,0 +1,104 @@
+const fs = require('fs');
+const path = require('path');
+
+const routesPath = path.resolve(__dirname, '../src/seo/routes.json');
+const config = JSON.parse(fs.readFileSync(routesPath, 'utf8'));
+
+config.routes['/cases/events'] = {
+  indexable: true,
+  kind: 'webPage',
+  title: 'События и выступления — кейсы Anix Studio',
+  description:
+    'Кейсы Anix Studio для событий и выступлений: AI-ролики, режиссура, презентации и экранный контент для большой аудитории.',
+  ogTitle: 'События и выступления — кейсы Anix Studio',
+  ogDescription: 'AI-ролики, режиссура, презентации и экранный контент для событий.',
+  ogImage: '/og/home.jpg',
+  h1: 'События и выступления',
+  intro:
+    'Проекты, где сценарий, сцена и экран работают как одно целое: AI-ролики, режиссура выступлений, презентации и контент для событий.',
+  sections: [
+    {
+      heading: 'Кейсы направления',
+      body: 'Собираем не набор отдельных материалов, а цельную историю для сцены и экрана.',
+    },
+    {
+      heading: 'Подход Anix',
+      body: 'Начинаем с реакции аудитории, затем проектируем драматургию, визуальный язык и производственный пайплайн.',
+    },
+  ],
+  links: [
+    { label: 'Все кейсы Anix Studio', href: '/cases' },
+    { label: 'Anix Studio', href: '/' },
+  ],
+  breadcrumbs: [
+    { label: 'Главная', href: '/' },
+    { label: 'Кейсы', href: '/cases' },
+    { label: 'События и выступления', href: '/cases/events' },
+  ],
+};
+
+config.routes['/cases/rchk'] = {
+  indexable: true,
+  kind: 'case',
+  title: 'Кейс РЧК: AI-ролик и технологическое шоу — Anix Studio',
+  description:
+    'Как Anix Studio собрала получасовое выступление для РЧК: сценарий, режиссуру, презентации и 5,5-минутный AI-ролик с реальными героями.',
+  ogTitle: 'РЧК: AI-ролик и технологическое шоу — Anix Studio',
+  ogDescription:
+    'Получасовое выступление и 5,5-минутный AI-ролик с девятью героями и восемью сгенерированными мирами.',
+  ogImage: '/og/home.jpg',
+  h1: 'РЧК: как превратить внутреннее выступление в технологическое шоу',
+  intro:
+    'Полчаса сценического действия, шесть типов контента и главный герой — 5,5-минутный AI-ролик, ради которого Anix собрала полноценный production киношного уровня.',
+  case: {
+    category: 'Events / AI production',
+    result: 'Вау-эффект подтверждён на тестовых просмотрах',
+    tags: 'event / AI-video / режиссура / production',
+    image: '/og/home.jpg',
+    imageAlt: 'Кейс РЧК — AI-ролик и сопровождение выступления Anix Studio',
+    relatedPath: '/cases/events',
+  },
+  sections: [
+    {
+      heading: 'Задача',
+      body: 'Собрать получасовое выступление для большой внутренней аудитории в контуре столичного департамента и превзойти высокую планку прошлогоднего интерактива.',
+    },
+    {
+      heading: 'Главный ролик',
+      body: 'В 5,5-минутном репортаже девять сотрудников РЧК стали героями с суперспособностями, а реальная съёмка соединилась с восемью AI-локациями, motion design и композингом.',
+    },
+    {
+      heading: 'Полное сопровождение',
+      body: 'Anix отвечала за сценарий и режиссуру блока, ролик-интервью, презентации спикеров, фоновую анимацию и обновлённую говорящую голову руководителя.',
+    },
+    {
+      heading: 'Production',
+      body: 'За месяц команда из семи человек произвела весь комплекс материалов. Чистое производство главного ролика заняло две недели: три версии, пересъёмки и ручная доработка сцен на потолке возможностей нейротехнологий.',
+    },
+    {
+      heading: 'Результат',
+      body: 'Главный ролик прошёл тестовые просмотры и получил оценку «очень круто». Выступление ещё впереди; после премьеры кейс дополнится реакцией зала и материалами события.',
+    },
+  ],
+  links: [
+    { label: 'Все кейсы Anix', href: '/cases' },
+    { label: 'События и выступления', href: '/cases/events' },
+    { label: 'Anix Studio', href: '/' },
+  ],
+  breadcrumbs: [
+    { label: 'Главная', href: '/' },
+    { label: 'Кейсы', href: '/cases' },
+    { label: 'РЧК', href: '/cases/rchk' },
+  ],
+};
+
+const casesRoute = config.routes['/cases'];
+if (casesRoute?.links && !casesRoute.links.some((item) => item.href === '/cases/events')) {
+  casesRoute.links.splice(-1, 0, {
+    label: 'События и выступления',
+    href: '/cases/events',
+  });
+}
+
+fs.writeFileSync(routesPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+console.log('[rchk-case] ensured /cases/events and /cases/rchk');

--- a/src/components/CasesCategoryPage.jsx
+++ b/src/components/CasesCategoryPage.jsx
@@ -1,5 +1,13 @@
 import React from 'react';
-import { ArrowLeft, ArrowRight, Camera, HardHat, Stethoscope, Workflow } from 'lucide-react';
+import {
+  ArrowLeft,
+  ArrowRight,
+  Camera,
+  HardHat,
+  Sparkles,
+  Stethoscope,
+  Workflow,
+} from 'lucide-react';
 import BrandLogo from './BrandLogo';
 import SiteFooter from './SiteFooter';
 import agrotechImage from '../images/cases/agrotech.webp';
@@ -144,6 +152,22 @@ const categoryConfig = {
       },
     ],
   },
+  '/cases/events': {
+    eyebrow: 'Events / AI production',
+    title: 'События и выступления',
+    description:
+      'Проекты, где сценарий, сцена и экран работают как одно целое: AI-ролики, режиссура выступлений, презентации и контент для событий.',
+    icon: Sparkles,
+    cases: [
+      {
+        title: 'РЧК: технологическое шоу',
+        image: null,
+        placeholder: 'Р',
+        note: 'Получасовое выступление и 5,5-минутный AI-ролик с девятью реальными героями и восемью сгенерированными мирами.',
+        href: '/cases/rchk/',
+      },
+    ],
+  },
 };
 
 function CategoryCaseCard({ item }) {
@@ -153,7 +177,11 @@ function CategoryCaseCard({ item }) {
         className={`cases-hub-card__media${item.image ? '' : ' cases-hub-card__media--placeholder'}`}
       >
         {item.image ? (
-          <img src={item.image} alt={`Кейс Anix: ${item.title}`} loading="lazy" />
+          <img
+            src={item.image}
+            alt={`Кейс Anix: ${item.title}`}
+            loading="lazy"
+          />
         ) : (
           <span>{item.placeholder}</span>
         )}
@@ -169,7 +197,8 @@ function CategoryCaseCard({ item }) {
     </>
   );
 
-  if (!item.href) return <article className="cases-hub-card">{content}</article>;
+  if (!item.href)
+    return <article className="cases-hub-card">{content}</article>;
 
   const external = /^https?:\/\//.test(item.href);
   return (
@@ -192,7 +221,11 @@ export default function CasesCategoryPage({ path }) {
   return (
     <main className="cases-hub-page cases-category-page">
       <header className="cases-hub-header">
-        <a href="/" className="cases-hub-logo" aria-label="Anix Studio — на главную">
+        <a
+          href="/"
+          className="cases-hub-logo"
+          aria-label="Anix Studio — на главную"
+        >
           <BrandLogo alt="Anix Studio" width={120} height={44} />
         </a>
         <a

--- a/src/components/CasesHubPage.jsx
+++ b/src/components/CasesHubPage.jsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { ArrowRight, Camera, HardHat, Sparkles, Stethoscope, Workflow } from 'lucide-react';
+import {
+  ArrowRight,
+  Camera,
+  HardHat,
+  Sparkles,
+  Stethoscope,
+  Workflow,
+} from 'lucide-react';
 import BrandLogo from './BrandLogo';
 import SiteFooter from './SiteFooter';
 import agrotechImage from '../images/cases/agrotech.webp';
@@ -158,6 +165,24 @@ const categories = [
       },
     ],
   },
+  {
+    id: 'events',
+    eyebrow: 'Events / AI production',
+    title: 'События и выступления',
+    description:
+      'Собираем сценические блоки как цельную историю: сценарий, режиссура, экранный контент, AI-визуалы, презентации и материалы вокруг события.',
+    icon: Sparkles,
+    cases: [
+      {
+        title: 'РЧК: технологическое шоу',
+        image: null,
+        note: 'Получасовое выступление и 5,5-минутный AI-ролик с реальными героями, суперспособностями и восемью мирами.',
+        href: '/cases/rchk/',
+        placeholder: 'Р',
+        featured: true,
+      },
+    ],
+  },
 ];
 
 function CaseCard({ item }) {
@@ -167,7 +192,11 @@ function CaseCard({ item }) {
         className={`cases-hub-card__media${item.image ? '' : ' cases-hub-card__media--placeholder'}`}
       >
         {item.image ? (
-          <img src={item.image} alt={`Кейс Anix: ${item.title}`} loading="lazy" />
+          <img
+            src={item.image}
+            alt={`Кейс Anix: ${item.title}`}
+            loading="lazy"
+          />
         ) : (
           <span>{item.placeholder}</span>
         )}
@@ -185,7 +214,9 @@ function CaseCard({ item }) {
 
   if (!item.href) {
     return (
-      <article className={`cases-hub-card${item.featured ? ' cases-hub-card--featured' : ''}`}>
+      <article
+        className={`cases-hub-card${item.featured ? ' cases-hub-card--featured' : ''}`}
+      >
         {content}
       </article>
     );
@@ -208,7 +239,11 @@ export default function CasesHubPage() {
   return (
     <main className="cases-hub-page">
       <header className="cases-hub-header">
-        <a href="/" className="cases-hub-logo" aria-label="Anix Studio — на главную">
+        <a
+          href="/"
+          className="cases-hub-logo"
+          aria-label="Anix Studio — на главную"
+        >
           <BrandLogo alt="Anix Studio" width={120} height={44} />
         </a>
         <a
@@ -223,20 +258,26 @@ export default function CasesHubPage() {
       <section className="cases-hub-hero">
         <p className="cases-hub-eyebrow">Кейсы Anix Studio</p>
         <h1>Сложные продукты, которые стали понятными историями</h1>
-        <p>Здесь собраны проекты для технологий, B2B, фармы, MedTech, кино и охраны труда.</p>
+        <p>
+          Здесь собраны проекты для технологий, B2B, фармы, MedTech, кино и
+          охраны труда.
+        </p>
         <nav className="cases-hub-jump" aria-label="Категории кейсов">
           {categories.map((category) => (
             <a href={`/cases/${category.id}/`} key={category.id}>
               {category.title}
             </a>
           ))}
-          <a href="#events">Events</a>
         </nav>
       </section>
       {categories.map((category) => {
         const Icon = category.icon;
         return (
-          <section className="cases-hub-category" id={category.id} key={category.id}>
+          <section
+            className="cases-hub-category"
+            id={category.id}
+            key={category.id}
+          >
             <div className="cases-hub-category__head">
               <div className="cases-hub-category__icon">
                 <Icon aria-hidden="true" />
@@ -262,20 +303,12 @@ export default function CasesHubPage() {
           </section>
         );
       })}
-      <section className="cases-hub-events" id="events">
-        <div className="cases-hub-events__icon">
-          <Sparkles aria-hidden="true" />
-        </div>
-        <p className="cases-hub-eyebrow">Events</p>
-        <h2>Скоро</h2>
-        <p>Добавим проекты с экранным контентом, AI-визуалами и режиссурой событий.</p>
-      </section>
       <section className="cases-hub-cta">
         <p className="cases-hub-eyebrow">Новая задача</p>
         <h2>Не нашли кейс ровно из вашей отрасли?</h2>
         <p>
-          Покажите продукт или идею. Разберёмся в задаче и предложим формат, который имеет смысл
-          именно для неё.
+          Покажите продукт или идею. Разберёмся в задаче и предложим формат,
+          который имеет смысл именно для неё.
         </p>
         <a href="https://t.me/anix_helper" target="_blank" rel="noreferrer">
           Обсудить проект <ArrowRight aria-hidden="true" />

--- a/src/components/RchkCasePage.css
+++ b/src/components/RchkCasePage.css
@@ -1,0 +1,614 @@
+.rchk-page {
+  --ink: #17111d;
+  --muted: #625a68;
+  --paper: #f6f1e9;
+  --acid: #dfff72;
+  --violet: #7a45ff;
+  min-height: 100vh;
+  overflow: hidden;
+  background: var(--paper);
+  color: var(--ink);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif;
+}
+
+.rchk-page *,
+.rchk-page *::before,
+.rchk-page *::after {
+  box-sizing: border-box;
+}
+.rchk-page a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.rchk-header {
+  position: sticky;
+  top: 16px;
+  z-index: 30;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 28px;
+  width: calc(100% - clamp(32px, 5vw, 96px));
+  margin: 16px auto 0;
+  padding: 10px 12px 10px 18px;
+  border: 1px solid rgba(23, 17, 29, 0.12);
+  border-radius: 999px;
+  background: rgba(255, 250, 242, 0.82);
+  box-shadow: 0 18px 50px rgba(23, 17, 29, 0.08);
+  backdrop-filter: blur(20px);
+}
+
+.rchk-header img {
+  display: block;
+  width: 92px;
+  height: auto;
+}
+.rchk-header nav {
+  display: flex;
+  justify-content: center;
+  gap: 24px;
+  font-size: 13px;
+  font-weight: 780;
+}
+.rchk-header-cta {
+  padding: 13px 20px;
+  border-radius: 999px;
+  background: var(--ink);
+  color: #fff !important;
+  font-size: 13px;
+  font-weight: 820;
+}
+
+.rchk-hero,
+.rchk-metrics,
+.rchk-section,
+.rchk-reportage,
+.rchk-limit,
+.rchk-final-cta {
+  width: min(1500px, calc(100% - clamp(40px, 7vw, 132px)));
+  margin-inline: auto;
+}
+
+.rchk-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.06fr) minmax(420px, 0.94fr);
+  align-items: center;
+  gap: clamp(48px, 6vw, 110px);
+  min-height: calc(100vh - 100px);
+  padding: clamp(76px, 9vw, 150px) 0;
+}
+
+.rchk-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 42px;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 800;
+}
+.rchk-back svg {
+  width: 18px;
+}
+.rchk-eyebrow {
+  margin: 0 0 18px;
+  color: #766c7c;
+  font-size: 12px;
+  font-weight: 850;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.rchk-hero h1 {
+  max-width: 900px;
+  margin: 0;
+  font-size: clamp(58px, 7.5vw, 126px);
+  line-height: 0.89;
+  letter-spacing: -0.058em;
+}
+.rchk-lead {
+  max-width: 800px;
+  margin: 34px 0 0;
+  color: var(--muted);
+  font-size: clamp(19px, 1.7vw, 28px);
+  font-weight: 580;
+  line-height: 1.42;
+}
+
+.rchk-hero-result {
+  display: grid;
+  gap: 8px;
+  max-width: 760px;
+  margin-top: 36px;
+  padding: 24px 0;
+  border-block: 1px solid rgba(23, 17, 29, 0.14);
+}
+.rchk-hero-result span {
+  color: #776d7d;
+  font-size: 11px;
+  font-weight: 850;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.rchk-hero-result strong {
+  font-size: clamp(25px, 2.3vw, 42px);
+  line-height: 1.08;
+}
+
+.rchk-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 30px;
+}
+.rchk-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  min-height: 52px;
+  padding: 0 22px;
+  border-radius: 999px;
+  font-size: 14px;
+  font-weight: 830;
+}
+.rchk-button svg {
+  width: 18px;
+  height: 18px;
+}
+.rchk-button-primary {
+  background: var(--ink);
+  color: #fff !important;
+}
+.rchk-button-secondary {
+  border: 1px solid rgba(23, 17, 29, 0.18);
+  background: rgba(255, 255, 255, 0.34);
+}
+
+.rchk-hero-visual {
+  position: relative;
+  isolation: isolate;
+  min-height: min(700px, 75vh);
+  overflow: hidden;
+  border-radius: 48px;
+  background:
+    radial-gradient(
+      circle at 27% 23%,
+      rgba(223, 255, 114, 0.95),
+      transparent 23%
+    ),
+    radial-gradient(
+      circle at 74% 78%,
+      rgba(255, 111, 222, 0.82),
+      transparent 25%
+    ),
+    linear-gradient(145deg, #17111d 4%, #5031a0 46%, #8a58ff 100%);
+  box-shadow: 0 36px 100px rgba(45, 24, 87, 0.27);
+}
+.rchk-hero-visual::before {
+  content: '';
+  position: absolute;
+  inset: 7%;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 40px;
+}
+.rchk-orbit {
+  position: absolute;
+  border: 1px solid rgba(255, 255, 255, 0.34);
+  border-radius: 50%;
+  transform: rotate(-28deg);
+}
+.rchk-orbit-one {
+  inset: 18% -10%;
+}
+.rchk-orbit-two {
+  inset: -15% 22%;
+  transform: rotate(37deg);
+}
+.rchk-visual-center {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  text-align: center;
+}
+.rchk-visual-center span,
+.rchk-visual-center small {
+  font-size: 12px;
+  font-weight: 850;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.rchk-visual-center strong {
+  font-size: clamp(94px, 12vw, 190px);
+  line-height: 0.85;
+  letter-spacing: -0.08em;
+}
+.rchk-visual-center small {
+  margin-top: 20px;
+  color: var(--acid);
+}
+.rchk-visual-chip {
+  position: absolute;
+  z-index: 2;
+  padding: 11px 16px;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: 999px;
+  background: rgba(23, 17, 29, 0.36);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 760;
+  backdrop-filter: blur(12px);
+}
+.rchk-chip-one {
+  top: 16%;
+  left: 10%;
+}
+.rchk-chip-two {
+  top: 23%;
+  right: 8%;
+}
+.rchk-chip-three {
+  right: 14%;
+  bottom: 13%;
+}
+.rchk-visual-spark {
+  position: absolute;
+  bottom: 11%;
+  left: 12%;
+  width: 70px;
+  height: 70px;
+  color: var(--acid);
+}
+
+.rchk-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  margin-bottom: clamp(100px, 12vw, 190px);
+  border-block: 1px solid rgba(23, 17, 29, 0.14);
+}
+.rchk-metrics div {
+  display: grid;
+  gap: 8px;
+  padding: 32px clamp(16px, 3vw, 44px);
+  border-right: 1px solid rgba(23, 17, 29, 0.14);
+}
+.rchk-metrics div:nth-child(3n) {
+  border-right: 0;
+}
+.rchk-metrics div:nth-child(-n + 3) {
+  border-bottom: 1px solid rgba(23, 17, 29, 0.14);
+}
+.rchk-metrics strong {
+  font-size: clamp(38px, 4vw, 70px);
+  line-height: 1;
+  letter-spacing: -0.05em;
+}
+.rchk-metrics span {
+  color: var(--muted);
+  font-size: 14px;
+  font-weight: 680;
+}
+
+.rchk-section {
+  display: grid;
+  grid-template-columns: minmax(150px, 0.28fr) minmax(0, 1fr);
+  gap: clamp(40px, 8vw, 140px);
+  padding: clamp(90px, 11vw, 180px) 0;
+  border-top: 1px solid rgba(23, 17, 29, 0.14);
+}
+.rchk-section-label {
+  color: #796f80;
+  font-size: 12px;
+  font-weight: 820;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.rchk-section-label span {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--ink);
+  font-size: 28px;
+  letter-spacing: -0.03em;
+}
+.rchk-section h2,
+.rchk-reportage h2,
+.rchk-limit h2,
+.rchk-final-cta h2 {
+  max-width: 1150px;
+  margin: 0;
+  font-size: clamp(48px, 6.7vw, 108px);
+  line-height: 0.94;
+  letter-spacing: -0.052em;
+}
+.rchk-section > div:last-child > p:not(.rchk-eyebrow, .rchk-result-note) {
+  max-width: 900px;
+  margin: 34px 0 0;
+  color: var(--muted);
+  font-size: clamp(19px, 1.7vw, 27px);
+  line-height: 1.52;
+}
+.rchk-challenge blockquote {
+  display: flex;
+  gap: 22px;
+  max-width: 1000px;
+  margin: 52px 0 0;
+  padding: 34px;
+  border: 0;
+  border-radius: 28px;
+  background: var(--ink);
+  color: #fff;
+  font-size: clamp(22px, 2.4vw, 38px);
+  font-weight: 730;
+  line-height: 1.25;
+}
+.rchk-challenge blockquote svg {
+  flex: 0 0 auto;
+  width: 34px;
+  height: 34px;
+  color: var(--acid);
+}
+
+.rchk-scope-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 60px;
+}
+.rchk-scope-grid article {
+  min-height: 310px;
+  padding: clamp(26px, 3vw, 42px);
+  border: 1px solid rgba(23, 17, 29, 0.1);
+  border-radius: 32px;
+  background: rgba(255, 255, 255, 0.42);
+}
+.rchk-scope-grid article > svg {
+  width: 34px;
+  height: 34px;
+  color: var(--violet);
+}
+.rchk-scope-grid h3 {
+  margin: 62px 0 16px;
+  font-size: clamp(28px, 3vw, 44px);
+  letter-spacing: -0.035em;
+}
+.rchk-scope-grid p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 17px;
+  line-height: 1.55;
+}
+
+.rchk-reportage {
+  display: grid;
+  grid-template-columns: 0.88fr 1.12fr;
+  gap: clamp(50px, 9vw, 150px);
+  align-items: end;
+  padding: clamp(76px, 9vw, 130px);
+  border-radius: 52px;
+  background: var(--ink);
+  color: #fff;
+}
+.rchk-reportage .rchk-eyebrow {
+  color: var(--acid);
+}
+.rchk-reportage-copy > p:last-child {
+  max-width: 680px;
+  margin: 34px 0 0;
+  color: rgba(255, 255, 255, 0.68);
+  font-size: clamp(18px, 1.6vw, 25px);
+  line-height: 1.55;
+}
+.rchk-superpowers {
+  display: grid;
+}
+.rchk-superpowers div {
+  display: grid;
+  grid-template-columns: 48px 1fr;
+  padding: 26px 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.18);
+}
+.rchk-superpowers span {
+  color: var(--acid);
+  font-size: 12px;
+  font-weight: 850;
+}
+.rchk-superpowers strong {
+  font-size: clamp(25px, 2.6vw, 42px);
+  line-height: 1;
+}
+.rchk-superpowers small {
+  grid-column: 2;
+  margin-top: 8px;
+  color: rgba(255, 255, 255, 0.52);
+  font-size: 14px;
+}
+
+.rchk-production-list {
+  margin-top: 64px;
+  border-top: 1px solid rgba(23, 17, 29, 0.14);
+}
+.rchk-production-list article {
+  display: grid;
+  grid-template-columns: 68px 1fr;
+  gap: 24px;
+  padding: 42px 0;
+  border-bottom: 1px solid rgba(23, 17, 29, 0.14);
+}
+.rchk-production-list article > span {
+  color: var(--violet);
+  font-size: 13px;
+  font-weight: 850;
+}
+.rchk-production-list h3 {
+  margin: 0;
+  font-size: clamp(30px, 3.4vw, 54px);
+  letter-spacing: -0.04em;
+}
+.rchk-production-list p {
+  max-width: 880px;
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-size: 18px;
+  line-height: 1.58;
+}
+
+.rchk-limit {
+  display: grid;
+  grid-template-columns: 1.08fr 0.72fr;
+  gap: clamp(50px, 9vw, 150px);
+  align-items: end;
+  padding: clamp(80px, 10vw, 150px);
+  border-radius: 52px;
+  background: linear-gradient(145deg, #dfff72 0%, #c7ff39 100%);
+}
+.rchk-limit svg {
+  width: 42px;
+  height: 42px;
+  margin-bottom: 34px;
+}
+.rchk-limit .rchk-eyebrow {
+  color: rgba(23, 17, 29, 0.58);
+}
+.rchk-limit > p {
+  margin: 0;
+  font-size: clamp(19px, 1.7vw, 26px);
+  line-height: 1.55;
+}
+
+.rchk-result-note {
+  max-width: 900px;
+  margin: 32px 0 0;
+  padding-left: 22px;
+  border-left: 3px solid var(--violet);
+  color: #776d7d;
+  font-size: 16px;
+  line-height: 1.55;
+}
+.rchk-final-cta {
+  margin-bottom: clamp(80px, 10vw, 150px);
+  padding: clamp(80px, 10vw, 150px);
+  border-radius: 52px;
+  background:
+    radial-gradient(circle at 90% 0, #7445ee 0, transparent 34%), var(--ink);
+  color: #fff;
+}
+.rchk-final-cta .rchk-eyebrow {
+  color: var(--acid);
+}
+.rchk-button-light {
+  background: var(--acid);
+  color: var(--ink) !important;
+}
+.rchk-button-ghost {
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  color: #fff !important;
+}
+
+@media (max-width: 980px) {
+  .rchk-header {
+    grid-template-columns: 1fr auto;
+  }
+  .rchk-header nav {
+    display: none;
+  }
+  .rchk-hero {
+    grid-template-columns: 1fr;
+  }
+  .rchk-hero-visual {
+    min-height: 580px;
+  }
+  .rchk-reportage,
+  .rchk-limit {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .rchk-header {
+    top: 8px;
+    width: calc(100% - 24px);
+    margin-top: 8px;
+  }
+  .rchk-header-cta {
+    padding: 11px 14px;
+    font-size: 11px;
+  }
+  .rchk-hero,
+  .rchk-metrics,
+  .rchk-section,
+  .rchk-reportage,
+  .rchk-limit,
+  .rchk-final-cta {
+    width: min(100% - 30px, 640px);
+  }
+  .rchk-hero {
+    padding-top: 68px;
+  }
+  .rchk-hero h1 {
+    font-size: clamp(50px, 15vw, 78px);
+  }
+  .rchk-hero-visual {
+    min-height: 460px;
+    border-radius: 32px;
+  }
+  .rchk-visual-center strong {
+    font-size: 100px;
+  }
+  .rchk-chip-three {
+    right: 7%;
+  }
+  .rchk-metrics {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .rchk-metrics div,
+  .rchk-metrics div:nth-child(3n) {
+    border-right: 1px solid rgba(23, 17, 29, 0.14);
+    border-bottom: 1px solid rgba(23, 17, 29, 0.14);
+  }
+  .rchk-metrics div:nth-child(2n) {
+    border-right: 0;
+  }
+  .rchk-metrics div:nth-last-child(-n + 2) {
+    border-bottom: 0;
+  }
+  .rchk-section {
+    grid-template-columns: 1fr;
+    gap: 36px;
+  }
+  .rchk-section-label span {
+    display: inline;
+    margin-right: 8px;
+  }
+  .rchk-scope-grid {
+    grid-template-columns: 1fr;
+  }
+  .rchk-scope-grid article {
+    min-height: 260px;
+  }
+  .rchk-reportage,
+  .rchk-limit,
+  .rchk-final-cta {
+    padding: 52px 26px;
+    border-radius: 34px;
+  }
+  .rchk-production-list article {
+    grid-template-columns: 42px 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rchk-page * {
+    scroll-behavior: auto !important;
+  }
+}

--- a/src/components/RchkCasePage.jsx
+++ b/src/components/RchkCasePage.jsx
@@ -1,0 +1,323 @@
+import React from 'react';
+import {
+  ArrowLeft,
+  ArrowRight,
+  Clock3,
+  Film,
+  Layers3,
+  MessageCircle,
+  Presentation,
+  Sparkles,
+  Users,
+  WandSparkles,
+} from 'lucide-react';
+import BrandLogo from './BrandLogo';
+import Breadcrumbs from './Breadcrumbs';
+import SiteFooter from './SiteFooter';
+import './RchkCasePage.css';
+
+const telegramUrl = 'https://t.me/anix_helper';
+const clientUrl = 'https://рчк.москва/';
+
+const metrics = [
+  ['5,5 мин', 'главный AI-ролик'],
+  ['9', 'сотрудников РЧК в кадре'],
+  ['8', 'уникальных AI-локаций'],
+  ['90%', 'кадров с AI'],
+  ['2 недели', 'чистое производство ролика'],
+  ['7 человек', 'команда Anix'],
+];
+
+const scope = [
+  {
+    icon: Film,
+    title: 'Главный AI-ролик',
+    text: '5,5 минут кинематографичного репортажа с реальными героями, суперспособностями и восемью сгенерированными мирами.',
+  },
+  {
+    icon: Presentation,
+    title: 'Всё выступление',
+    text: 'Сценарий получасового блока, режиссура, несколько презентаций для спикеров и единая логика выхода материалов на сцене.',
+  },
+  {
+    icon: Users,
+    title: 'Контент вокруг ролика',
+    text: 'Отдельный 1,5-минутный ролик-интервью, фоновая анимация для экранов и обновлённая «говорящая голова» руководителя.',
+  },
+  {
+    icon: Layers3,
+    title: 'Гибридный production',
+    text: 'Съёмки, AI-генерация, композинг, motion design, монтаж, звук и ручная доработка сошлись в одном пайплайне.',
+  },
+];
+
+const production = [
+  [
+    '01',
+    'Собрали драматургию',
+    'Придумали формат репортажа: корреспондент проходит путь молодого человека в Москве и через него показывает, чем РЧК помогает людям и бизнесу.',
+  ],
+  [
+    '02',
+    'Сняли реальных героев',
+    'В кадре появились девять сотрудников РЧК. Съёмка дала живые эмоции и узнаваемость, которые особенно важны для внутренней аудитории.',
+  ],
+  [
+    '03',
+    'Построили восемь миров',
+    'Каждому смысловому блоку — своя среда и своя суперспособность: порталы, взгляд в будущее стартапов, золотая перчатка бесконечного количества партнёров и другие визуальные метафоры.',
+  ],
+  [
+    '04',
+    'Довели до кино',
+    'AI был не финальной кнопкой, а материалом. Мы собирали кадры слоями, исправляли артефакты, делали композ, графику, монтаж и звук, чтобы генерации стали цельным фильмом.',
+  ],
+];
+
+export default function RchkCasePage() {
+  return (
+    <main className="rchk-page">
+      <header className="rchk-header">
+        <a href="/" aria-label="Anix Studio — на главную">
+          <BrandLogo alt="Anix Studio" width={120} height={44} />
+        </a>
+        <nav aria-label="Навигация по кейсу">
+          <a href="#challenge">Задача</a>
+          <a href="#production">Production</a>
+          <a href="#result">Результат</a>
+        </nav>
+        <a
+          className="rchk-header-cta"
+          href={telegramUrl}
+          target="_blank"
+          rel="noreferrer"
+        >
+          Обсудить проект
+        </a>
+      </header>
+
+      <Breadcrumbs path="/cases/rchk" />
+
+      <section className="rchk-hero">
+        <div className="rchk-hero-copy">
+          <a className="rchk-back" href="/cases/events/">
+            <ArrowLeft aria-hidden="true" /> Events
+          </a>
+          <p className="rchk-eyebrow">
+            Anix Studio × АНО «Развитие человеческого капитала»
+          </p>
+          <h1>Как превратить внутреннее выступление в технологическое шоу</h1>
+          <p className="rchk-lead">
+            Полчаса сценического действия, шесть типов контента и главный герой
+            — 5,5-минутный AI-ролик, ради которого мы собирали полноценный
+            production киношного уровня.
+          </p>
+          <div className="rchk-hero-result">
+            <span>Результат на тестовых просмотрах</span>
+            <strong>«Очень круто». Вау-эффект сработал.</strong>
+          </div>
+          <div className="rchk-actions">
+            <a className="rchk-button rchk-button-primary" href="#story">
+              Разобрать кейс <ArrowRight aria-hidden="true" />
+            </a>
+            <a
+              className="rchk-button rchk-button-secondary"
+              href={clientUrl}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Сайт РЧК
+            </a>
+          </div>
+        </div>
+
+        <div
+          className="rchk-hero-visual"
+          role="img"
+          aria-label="Визуальная схема AI-ролика РЧК продолжительностью пять с половиной минут"
+        >
+          <div className="rchk-orbit rchk-orbit-one" />
+          <div className="rchk-orbit rchk-orbit-two" />
+          <span className="rchk-visual-chip rchk-chip-one">real shoot</span>
+          <span className="rchk-visual-chip rchk-chip-two">AI worlds</span>
+          <span className="rchk-visual-chip rchk-chip-three">compositing</span>
+          <Sparkles className="rchk-visual-spark" aria-hidden="true" />
+          <div className="rchk-visual-center">
+            <span>главный ролик</span>
+            <strong>5:30</strong>
+            <small>90% кадров с AI</small>
+          </div>
+        </div>
+      </section>
+
+      <section className="rchk-metrics" aria-label="Проект в цифрах">
+        {metrics.map(([value, label]) => (
+          <div key={label}>
+            <strong>{value}</strong>
+            <span>{label}</span>
+          </div>
+        ))}
+      </section>
+
+      <section className="rchk-section rchk-challenge" id="challenge">
+        <div className="rchk-section-label">
+          <span>01</span> Вызов
+        </div>
+        <div>
+          <p className="rchk-eyebrow">Планку уже подняли до нас</p>
+          <h2>
+            В прошлом году РЧК удивили зал «говорящей головой» руководителя. В
+            этом году нужно было сделать сильно мощнее.
+          </h2>
+          <p>
+            Запрос звучал не как «сделайте красивый ролик». Нужно было собрать
+            получасовое выступление для большой внутренней аудитории в контуре
+            столичного департамента — и добиться реакции: «Ну вы даёте. Как вы
+            вообще это сделали?»
+          </p>
+          <blockquote>
+            <WandSparkles aria-hidden="true" />
+            <span>
+              Не отдельный эффект, а цельное шоу, где каждый материал работает
+              на одно большое «вау».
+            </span>
+          </blockquote>
+        </div>
+      </section>
+
+      <section className="rchk-section rchk-scope" id="story">
+        <div className="rchk-section-label">
+          <span>02</span> Сопровождение
+        </div>
+        <div>
+          <p className="rchk-eyebrow">Anix отвечала за весь блок</p>
+          <h2>От первой реплики спикера до последнего пикселя на экране</h2>
+          <div className="rchk-scope-grid">
+            {scope.map(({ icon: Icon, title, text }) => (
+              <article key={title}>
+                <Icon aria-hidden="true" />
+                <h3>{title}</h3>
+                <p>{text}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="rchk-reportage">
+        <div className="rchk-reportage-copy">
+          <p className="rchk-eyebrow">Формат фильма</p>
+          <h2>Репортаж из мультивселенной РЧК</h2>
+          <p>
+            Корреспондент проходит путь молодого человека в Москве: от первой
+            точки входа до возможностей для карьеры и предпринимательства. По
+            дороге он встречает команду РЧК — и каждый герой показывает свою
+            суперспособность.
+          </p>
+        </div>
+        <div
+          className="rchk-superpowers"
+          aria-label="Примеры суперспособностей героев ролика"
+        >
+          <div>
+            <span>01</span>
+            <strong>Открывать порталы</strong>
+            <small>между возможностями</small>
+          </div>
+          <div>
+            <span>02</span>
+            <strong>Видеть будущее</strong>
+            <small>стартапов и команд</small>
+          </div>
+          <div>
+            <span>03</span>
+            <strong>Объединять партнёров</strong>
+            <small>в одном движении</small>
+          </div>
+        </div>
+      </section>
+
+      <section className="rchk-section rchk-production" id="production">
+        <div className="rchk-section-label">
+          <span>03</span> Production
+        </div>
+        <div>
+          <p className="rchk-eyebrow">Съёмка + AI + post-production</p>
+          <h2>Мы не генерировали ролик. Мы его производили.</h2>
+          <div className="rchk-production-list">
+            {production.map(([number, title, text]) => (
+              <article key={number}>
+                <span>{number}</span>
+                <div>
+                  <h3>{title}</h3>
+                  <p>{text}</p>
+                </div>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="rchk-limit">
+        <div>
+          <Clock3 aria-hidden="true" />
+          <p className="rchk-eyebrow">Один месяц на всю работу</p>
+          <h2>
+            Три версии ролика, пересъёмки и параллельное производство всех
+            материалов.
+          </h2>
+        </div>
+        <p>
+          Чистое производство главного ролика заняло две недели. На многих
+          сценах мы упирались в текущий потолок нейротехнологий — и не снижали
+          идею до возможностей одной модели, а меняли пайплайн, пересобирали
+          кадры и доводили их вручную.
+        </p>
+      </section>
+
+      <section className="rchk-section rchk-result" id="result">
+        <div className="rchk-section-label">
+          <span>04</span> Результат
+        </div>
+        <div>
+          <p className="rchk-eyebrow">До премьеры</p>
+          <h2>Технологическое чудо готово к выходу на сцену</h2>
+          <p>
+            РЧК получили не набор разрозненных материалов, а полностью собранное
+            выступление: сценарий, режиссуру, видео, презентации и экранную
+            графику. Главный ролик уже прошёл тестовые просмотры и получил
+            именно ту реакцию, ради которой всё затевалось — «очень круто» и
+            настоящее удивление от того, как это вообще было сделано.
+          </p>
+          <p className="rchk-result-note">
+            Публичное выступление ещё впереди. После мероприятия дополним кейс
+            кадрами, бэкстейджем и реакцией зала.
+          </p>
+        </div>
+      </section>
+
+      <section className="rchk-final-cta">
+        <p className="rchk-eyebrow">Следующая высокая планка</p>
+        <h2>
+          Нужно, чтобы после вашего выступления подходили и спрашивали: «Как вы
+          это сделали?»
+        </h2>
+        <div className="rchk-actions">
+          <a
+            className="rchk-button rchk-button-light"
+            href={telegramUrl}
+            target="_blank"
+            rel="noreferrer"
+          >
+            <MessageCircle aria-hidden="true" /> Обсудить проект
+          </a>
+          <a className="rchk-button rchk-button-ghost" href="/cases/">
+            Другие кейсы <ArrowRight aria-hidden="true" />
+          </a>
+        </div>
+      </section>
+
+      <SiteFooter />
+    </main>
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ const CasesCategoryPage = lazy(() => import('./components/CasesCategoryPage'));
 const CasePage = lazy(() => import('./components/CasePage'));
 const VerySweetCasePage = lazy(() => import('./components/VerySweetCasePage'));
 const AviandrCasePage = lazy(() => import('./components/AviandrCasePage'));
+const RchkCasePage = lazy(() => import('./components/RchkCasePage'));
 
 function RuntimeFallback({ failed = false }) {
   return (
@@ -63,7 +64,7 @@ const normalizedPath = (() => {
   return withoutIndex.endsWith('/') ? withoutIndex.slice(0, Math.max(1, withoutIndex.length - 1)) : withoutIndex;
 })();
 
-const categoryCasePaths = new Set(['/cases/b2b', '/cases/medicine', '/cases/cinema', '/cases/hse']);
+const categoryCasePaths = new Set(['/cases/b2b', '/cases/medicine', '/cases/cinema', '/cases/hse', '/cases/events']);
 const renderInLayout = (component) => {
   root.render(<RuntimeErrorBoundary><AppLayout><SeoHead path={normalizedPath} /><Suspense fallback={<RuntimeFallback />}>{component}</Suspense><AboutStudioPortal path={normalizedPath} /><CasesHubLinkPortal path={normalizedPath} /><RouteBreadcrumbsPortal path={normalizedPath} /><RouteRelatedLinksPortal path={normalizedPath} /></AppLayout></RuntimeErrorBoundary>);
 };
@@ -78,6 +79,8 @@ if (normalizedPath === '/hse/mvp' || normalizedPath.startsWith('/hse/mvp/')) {
   renderInLayout(<VerySweetCasePage />);
 } else if (normalizedPath === '/cases/aviandr') {
   renderInLayout(<AviandrCasePage />);
+} else if (normalizedPath === '/cases/rchk') {
+  renderInLayout(<RchkCasePage />);
 } else if (normalizedPath.startsWith('/cases/')) {
   renderInLayout(<CasePage path={normalizedPath} />);
 } else {


### PR DESCRIPTION
## Что изменилось

- добавлена отдельная большая страница кейса РЧК `/cases/rchk/`
- создано направление Events и карточка РЧК на общей странице кейсов
- добавлена карточка в отдельную категорию `/cases/events/`
- добавлены SEO-данные, хлебные крошки, sitemap/static routes и мобильная адаптация
- публичный текст не раскрывает внутреннее название мероприятия и честно отделяет тестовые просмотры от будущей премьеры

## Проверки

- `npm run lint`
- `CI=true npm test -- --watchAll=false` — 17/17
- `CI=false npm run build` — production build и SEO verification прошли
- `git diff --check`
