### PR TITLE
Launch the redesigned mobile homepage

### DIFF
--- a/src/Design1TestPage.css
+++ b/src/Design1TestPage.css
@@ -1659,7 +1659,6 @@
   -webkit-text-fill-color: currentColor;
 }
 
-
 /* content-fixes-part-2 */
 .d1-direction-card {
   border: 1px solid rgba(33, 22, 45, 0.12);
@@ -1667,30 +1666,710 @@
 }
 
 .d1-direction-grid > :nth-child(1),
-.d1-direction-grid > :nth-child(4) { background: #f0e8ff; color: #21162d; }
+.d1-direction-grid > :nth-child(4) {
+  background: #f0e8ff;
+  color: #21162d;
+}
 .d1-direction-grid > :nth-child(2),
-.d1-direction-grid > :nth-child(5) { border-color: rgba(255, 255, 255, 0.12); background: #21162d; color: #fff; }
-.d1-direction-grid > :nth-child(3) { background: #dfff72; color: #18131f; }
+.d1-direction-grid > :nth-child(5) {
+  border-color: rgba(255, 255, 255, 0.12);
+  background: #21162d;
+  color: #fff;
+}
+.d1-direction-grid > :nth-child(3) {
+  background: #dfff72;
+  color: #18131f;
+}
 .d1-direction-grid > :nth-child(1) h3,
 .d1-direction-grid > :nth-child(3) h3,
-.d1-direction-grid > :nth-child(4) h3 { color: #21162d; }
+.d1-direction-grid > :nth-child(4) h3 {
+  color: #21162d;
+}
 .d1-direction-grid > :nth-child(1) p,
-.d1-direction-grid > :nth-child(4) p { color: #62566d; }
-.d1-direction-grid > :nth-child(3) p { color: #44394d; }
+.d1-direction-grid > :nth-child(4) p {
+  color: #62566d;
+}
+.d1-direction-grid > :nth-child(3) p {
+  color: #44394d;
+}
 .d1-direction-grid > :nth-child(2) h3,
-.d1-direction-grid > :nth-child(5) h3 { color: #fff; }
+.d1-direction-grid > :nth-child(5) h3 {
+  color: #fff;
+}
 .d1-direction-grid > :nth-child(2) p,
-.d1-direction-grid > :nth-child(5) p { color: rgba(255,255,255,.76); }
+.d1-direction-grid > :nth-child(5) p {
+  color: rgba(255, 255, 255, 0.76);
+}
 .d1-direction-grid > :nth-child(1) .d1-icon-wrap,
 .d1-direction-grid > :nth-child(3) .d1-icon-wrap,
-.d1-direction-grid > :nth-child(4) .d1-icon-wrap { background: #21162d; color: #fff; }
+.d1-direction-grid > :nth-child(4) .d1-icon-wrap {
+  background: #21162d;
+  color: #fff;
+}
 .d1-direction-grid > :nth-child(2) .d1-icon-wrap,
-.d1-direction-grid > :nth-child(5) .d1-icon-wrap { background: #f0e8ff; color: #21162d; }
-.d1-direction-card > svg { color: currentColor; }
-.d1-direction-card, .d1-direction-card * { min-width: 0; }
-.d1-showreel-poster picture { display: block; width: 100%; height: 100%; }
-.d1-showreel-poster picture img { width: 100%; height: 100%; object-fit: cover; }
-.d1-cases, .d1-video-shelf, .d1-reasons, .d1-process, .d1-directions, .d1-trust {
+.d1-direction-grid > :nth-child(5) .d1-icon-wrap {
+  background: #f0e8ff;
+  color: #21162d;
+}
+.d1-direction-card > svg {
+  color: currentColor;
+}
+.d1-direction-card,
+.d1-direction-card * {
+  min-width: 0;
+}
+.d1-showreel-poster picture {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+.d1-showreel-poster picture img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.d1-cases,
+.d1-video-shelf,
+.d1-reasons,
+.d1-process,
+.d1-directions,
+.d1-trust {
   content-visibility: auto;
   contain-intrinsic-size: auto 900px;
+}
+
+/* Mobile app-style system. Kept at the end so desktop rules remain untouched. */
+.d1-mobile-copy,
+.d1-mobile-dock {
+  display: none;
+}
+
+@media (max-width: 640px) {
+  .design1-test {
+    --d1-mobile-gap: 12px;
+    padding-bottom: calc(76px + env(safe-area-inset-bottom));
+  }
+
+  .design1-test .d1-desktop-copy,
+  .design1-test .d1-microcopy,
+  .design1-test .d1-hero-eyebrow,
+  .design1-test .d1-hero-note,
+  .design1-test .d1-proof-layout > .d1-section-lead,
+  .design1-test #services .d1-section-lead,
+  .design1-test .d1-process-copy .d1-section-lead {
+    display: none;
+  }
+
+  .design1-test .d1-mobile-copy {
+    display: inline;
+  }
+
+  .design1-test .d1-container {
+    padding-inline: 16px;
+  }
+
+  .design1-test .d1-section {
+    padding-block: 44px;
+  }
+
+  .design1-test .d1-header {
+    top: 8px;
+    width: calc(100% - 20px) !important;
+    margin-top: 8px;
+  }
+
+  .design1-test .d1-header-inner {
+    min-height: 50px;
+    padding: 6px 7px 6px 13px;
+    border-radius: 18px;
+    box-shadow: 0 10px 30px rgba(17, 17, 17, 0.1);
+  }
+
+  .design1-test .d1-logo {
+    width: 66px;
+    min-width: 66px;
+  }
+
+  .design1-test .d1-header-cta {
+    position: static;
+    width: auto;
+    max-width: none;
+    min-height: 38px;
+    padding-inline: 15px;
+    border-radius: 13px;
+    font-size: 13px;
+  }
+
+  .design1-test .d1-hero {
+    gap: 22px;
+    min-height: auto;
+    padding-top: 34px;
+    padding-bottom: 38px;
+  }
+
+  .design1-test .d1-hero h1 {
+    font-size: clamp(38px, 11.2vw, 48px);
+    line-height: 0.93;
+    letter-spacing: -0.045em;
+  }
+
+  .design1-test .d1-lead {
+    margin-top: 18px;
+    font-size: 16px;
+    line-height: 1.32;
+    font-weight: 680;
+  }
+
+  .design1-test .d1-hero-actions {
+    display: grid;
+    grid-template-columns: minmax(0, 1.18fr) minmax(0, 0.82fr);
+    gap: 8px;
+    margin-top: 20px;
+  }
+
+  .design1-test .d1-button {
+    min-height: 46px;
+    padding-inline: 13px;
+    border-radius: 15px;
+    font-size: 13px;
+  }
+
+  .design1-test .d1-button svg {
+    width: 17px;
+    height: 17px;
+  }
+
+  .design1-test .d1-showreel-frame {
+    border-radius: 20px;
+    box-shadow: 0 18px 42px rgba(17, 17, 17, 0.17);
+  }
+
+  .design1-test .d1-play {
+    top: 12px;
+    right: 12px;
+    width: 46px;
+    height: 46px;
+  }
+
+  .design1-test .d1-play svg {
+    width: 24px;
+    height: 24px;
+  }
+
+  .design1-test .d1-showreel-label {
+    right: 16px;
+    bottom: 34px;
+    left: 16px;
+    font-size: 23px;
+  }
+
+  .design1-test .d1-showreel-tag {
+    right: 16px;
+    bottom: 14px;
+    left: 16px;
+    overflow: hidden;
+    font-size: 10px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .design1-test .d1-eyebrow {
+    margin-bottom: 9px;
+    font-size: 10px;
+    letter-spacing: 0.06em;
+  }
+
+  .design1-test .d1-section h2,
+  .design1-test .d1-final-cta h2 {
+    font-size: clamp(29px, 8.7vw, 37px);
+    line-height: 0.98;
+    letter-spacing: -0.035em;
+  }
+
+  .design1-test .d1-section-head {
+    gap: 0;
+    margin-bottom: 20px;
+  }
+
+  .design1-test .d1-proof {
+    padding-top: 30px;
+  }
+
+  .design1-test .d1-proof-layout,
+  .design1-test .d1-section-head-row,
+  .design1-test .d1-trust-layout {
+    gap: 16px;
+  }
+
+  .design1-test .d1-metrics-grid,
+  .design1-test .d1-case-grid,
+  .design1-test .d1-reason-grid {
+    display: flex;
+    width: calc(100% + 16px);
+    gap: 10px;
+    margin-top: 20px;
+    padding-right: 16px;
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+    scroll-snap-type: x mandatory;
+    scrollbar-width: none;
+  }
+
+  .design1-test .d1-metrics-grid::-webkit-scrollbar,
+  .design1-test .d1-case-grid::-webkit-scrollbar,
+  .design1-test .d1-reason-grid::-webkit-scrollbar,
+  .design1-test .d1-trust-chips::-webkit-scrollbar {
+    display: none;
+  }
+
+  .design1-test .d1-metric-card {
+    width: 148px;
+    min-width: 148px;
+    min-height: 132px;
+    padding: 16px;
+    border-radius: 19px;
+    scroll-snap-align: start;
+  }
+
+  .design1-test .d1-metric-card strong {
+    font-size: 35px;
+  }
+
+  .design1-test .d1-metric-card h3 {
+    margin-top: 18px;
+    font-size: 14px;
+    line-height: 1.12;
+  }
+
+  .design1-test .d1-service-grid,
+  .design1-test .d1-direction-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+  }
+
+  .design1-test .d1-service-card,
+  .design1-test .d1-direction-card {
+    min-height: 148px;
+    padding: 14px;
+    border-radius: 19px;
+  }
+
+  .design1-test .d1-icon-wrap {
+    width: 40px;
+    height: 40px;
+    border-radius: 13px;
+  }
+
+  .design1-test .d1-icon-wrap svg {
+    width: 20px;
+    height: 20px;
+  }
+
+  .design1-test .d1-service-card h3,
+  .design1-test .d1-direction-card h3 {
+    margin: auto 0 0;
+    font-size: 18px;
+    line-height: 1.02;
+  }
+
+  .design1-test .d1-service-card p,
+  .design1-test .d1-direction-card p {
+    display: none;
+  }
+
+  .design1-test .d1-direction-card > svg {
+    top: 16px;
+    right: 14px;
+    bottom: auto;
+    width: 18px;
+    height: 18px;
+  }
+
+  .design1-test .d1-case-grid {
+    margin-top: 0;
+  }
+
+  .design1-test .d1-case-card {
+    width: min(82vw, 318px);
+    min-width: min(82vw, 318px);
+    border-radius: 20px;
+    scroll-snap-align: start;
+  }
+
+  .design1-test .d1-case-image {
+    aspect-ratio: 16 / 9;
+  }
+
+  .design1-test .d1-case-body {
+    padding: 15px;
+  }
+
+  .design1-test .d1-case-category {
+    margin-bottom: 10px;
+    padding: 5px 8px;
+    font-size: 9px;
+  }
+
+  .design1-test .d1-case-body h3 {
+    font-size: 27px;
+  }
+
+  .design1-test .d1-case-body strong {
+    margin-top: 8px;
+    font-size: 14px;
+  }
+
+  .design1-test .d1-case-body > p,
+  .design1-test .d1-case-foot > span {
+    display: none;
+  }
+
+  .design1-test .d1-case-foot {
+    margin-top: 12px;
+    padding-top: 10px;
+  }
+
+  .design1-test .d1-text-link {
+    width: 100%;
+    justify-content: space-between;
+    min-height: 28px;
+    font-size: 12px;
+  }
+
+  .design1-test .d1-video-shelf {
+    padding-top: 26px;
+  }
+
+  .design1-test .d1-video-shelf .d1-section-head-row {
+    display: flex;
+    flex-direction: row;
+    align-items: end;
+    justify-content: space-between;
+  }
+
+  .design1-test .d1-video-shelf .d1-section-head-row > .d1-button {
+    width: 46px;
+    min-width: 46px;
+    padding: 0;
+    overflow: hidden;
+    color: transparent !important;
+    font-size: 0;
+  }
+
+  .design1-test .d1-video-shelf .d1-section-head-row > .d1-button svg {
+    color: var(--d1-white);
+  }
+
+  .design1-test .d1-compact-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+  }
+
+  .design1-test .d1-compact-case {
+    min-height: auto;
+    padding: 8px;
+    border-radius: 17px;
+  }
+
+  .design1-test .d1-compact-media {
+    margin-bottom: 10px;
+    border-radius: 12px;
+  }
+
+  .design1-test .d1-compact-title {
+    padding: 0 4px 5px;
+    font-size: 15px;
+  }
+
+  .design1-test .d1-compact-case p,
+  .design1-test .d1-compact-case > svg {
+    display: none;
+  }
+
+  .design1-test .d1-reasons {
+    margin-top: 18px;
+    border-radius: 26px 26px 0 0;
+  }
+
+  .design1-test .d1-reason-grid {
+    margin-top: 22px;
+  }
+
+  .design1-test .d1-reason-card {
+    width: 190px;
+    min-width: 190px;
+    min-height: 148px;
+    padding: 16px;
+    border-radius: 19px;
+    scroll-snap-align: start;
+  }
+
+  .design1-test .d1-reason-card span {
+    font-size: 38px;
+  }
+
+  .design1-test .d1-reason-card h3 {
+    margin: 30px 0 0;
+    font-size: 19px;
+  }
+
+  .design1-test .d1-reason-card p {
+    display: none;
+  }
+
+  .design1-test .d1-process-layout {
+    gap: 18px;
+  }
+
+  .design1-test .d1-process-step {
+    grid-template-columns: 36px 1fr;
+    gap: 8px;
+    align-items: center;
+    min-height: 58px;
+    padding: 10px 0;
+  }
+
+  .design1-test .d1-process-step > span {
+    font-size: 14px;
+  }
+
+  .design1-test .d1-process-step h3 {
+    font-size: 18px;
+  }
+
+  .design1-test .d1-process-step p {
+    display: none;
+  }
+
+  .design1-test .d1-trust {
+    padding-top: 24px;
+  }
+
+  .design1-test .d1-trust-layout {
+    padding: 18px;
+    border-radius: 20px;
+  }
+
+  .design1-test .d1-trust-layout h2 {
+    font-size: 30px;
+  }
+
+  .design1-test .d1-trust-chips {
+    flex-wrap: nowrap;
+    width: 100%;
+    margin: 0;
+    padding-right: 0;
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+    scrollbar-width: none;
+  }
+
+  .design1-test .d1-trust-chips::after {
+    width: 18px;
+    min-width: 18px;
+    content: '';
+  }
+
+  .design1-test .d1-trust-chips span {
+    flex: 0 0 auto;
+    min-height: 34px;
+    padding-inline: 10px;
+    font-size: 11px;
+  }
+
+  .design1-test .d1-final-cta {
+    padding-block: 46px;
+  }
+
+  .design1-test .d1-final-inner {
+    gap: 22px;
+  }
+
+  .design1-test .d1-final-cta p:not(.d1-eyebrow) {
+    margin-top: 12px;
+    font-size: 15px;
+    line-height: 1.35;
+  }
+
+  .design1-test .d1-final-actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    margin-top: 0;
+  }
+
+  .design1-test .d1-final-actions > :last-child {
+    grid-column: 1 / -1;
+  }
+
+  .design1-test .website-lead {
+    display: grid;
+    gap: 22px;
+    padding: 44px 16px;
+  }
+
+  .design1-test .website-lead__intro h2 {
+    font-size: clamp(32px, 9vw, 40px);
+    line-height: 0.98;
+  }
+
+  .design1-test .website-lead__intro > p:not(.website-lead__eyebrow) {
+    margin-top: 14px;
+    font-size: 15px;
+    line-height: 1.35;
+  }
+
+  .design1-test .website-lead__direct {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+    margin-top: 18px;
+  }
+
+  .design1-test .website-lead__direct > span {
+    display: none;
+  }
+
+  .design1-test .website-lead__direct a {
+    min-height: 44px;
+    padding-inline: 10px;
+    font-size: 12px;
+  }
+
+  .design1-test .website-lead__form {
+    padding: 16px;
+    border-radius: 20px;
+  }
+
+  .design1-test .website-lead__grid {
+    gap: 13px;
+  }
+
+  .design1-test .website-lead__form label {
+    gap: 6px;
+    font-size: 12px;
+  }
+
+  .design1-test .website-lead__form input {
+    min-height: 48px;
+    padding-inline: 13px;
+  }
+
+  .design1-test .website-lead__form textarea {
+    min-height: 110px;
+    padding: 13px;
+  }
+
+  .design1-test .website-lead__message,
+  .design1-test .website-lead__submit-row {
+    margin-top: 14px;
+  }
+
+  .design1-test .website-lead__form button[type='submit'] {
+    min-height: 50px;
+  }
+
+  .design1-test .anix-site-footer {
+    padding: 34px 16px 22px;
+  }
+
+  .design1-test .anix-site-footer__inner {
+    display: block;
+  }
+
+  .design1-test .anix-site-footer__brand {
+    gap: 0;
+  }
+
+  .design1-test .anix-site-footer__brand p,
+  .design1-test .anix-site-footer__nav,
+  .design1-test .anix-site-footer__contact {
+    display: none;
+  }
+
+  .design1-test .anix-site-footer__bottom {
+    gap: 10px;
+    margin-top: 24px;
+    padding-top: 16px;
+    font-size: 11px;
+  }
+
+  .design1-test .anix-site-footer__bottom > a:not(:nth-last-child(-n + 2)) {
+    display: none;
+  }
+
+  .design1-test .d1-mobile-dock {
+    position: fixed;
+    right: 10px;
+    bottom: calc(8px + env(safe-area-inset-bottom));
+    left: 10px;
+    z-index: 50;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    min-height: 62px;
+    padding: 6px;
+    border: 1px solid rgba(17, 17, 17, 0.14);
+    border-radius: 22px;
+    background: rgba(255, 250, 242, 0.9);
+    box-shadow: 0 16px 44px rgba(17, 17, 17, 0.2);
+    backdrop-filter: blur(22px);
+  }
+
+  .design1-test .d1-mobile-dock a {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    align-items: center;
+    justify-content: center;
+    min-width: 0;
+    min-height: 48px;
+    border-radius: 16px;
+    color: rgba(17, 17, 17, 0.66);
+    font-size: 9px;
+    font-weight: 800;
+  }
+
+  .design1-test .d1-mobile-dock a:last-child {
+    background: var(--d1-black);
+    color: var(--d1-white);
+  }
+
+  .design1-test .d1-mobile-dock svg {
+    width: 20px;
+    height: 20px;
+  }
+}
+
+@media (max-width: 370px) {
+  .design1-test .d1-hero h1 {
+    font-size: 36px;
+  }
+
+  .design1-test .d1-hero-actions,
+  .design1-test .d1-final-actions {
+    grid-template-columns: 1fr;
+  }
+
+  .design1-test .d1-final-actions > :last-child {
+    grid-column: auto;
+  }
+}
+
+/* youtube-showreel-fallback */
+.d1-showreel-external {
+  position: absolute;
+  right: 16px;
+  bottom: 16px;
+  z-index: 3;
+  padding: 10px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: 999px;
+  background: rgba(17, 17, 17, 0.82);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 760;
+  text-decoration: none;
+  backdrop-filter: blur(10px);
+}
+.d1-showreel-external:hover {
+  background: #111;
 }

--- a/src/__tests__/layout.test.js
+++ b/src/__tests__/layout.test.js
@@ -94,6 +94,18 @@ describe('current ANIX landing', () => {
     expect(container.querySelector('.anix-site-footer')).toBeTruthy();
   });
 
+  test('publishes all additional video cards with useful destinations', () => {
+    TestUtils.act(() => {
+      root.render(<App />);
+    });
+
+    const cards = Array.from(container.querySelectorAll('.d1-compact-case'));
+    expect(cards).toHaveLength(8);
+    expect(cards.every((card) => card.getAttribute('href') !== '#cases')).toBe(
+      true
+    );
+  });
+
   test('publishes the company details in the shared footer', () => {
     TestUtils.act(() => {
       root.render(<App />);

--- a/src/components/AboutStudioPortal.css
+++ b/src/components/AboutStudioPortal.css
@@ -1,7 +1,15 @@
 .d1-about-studio {
   background:
-    radial-gradient(circle at 14% 18%, rgba(19, 203, 178, 0.14), transparent 34%),
-    radial-gradient(circle at 88% 82%, rgba(157, 124, 255, 0.16), transparent 34%),
+    radial-gradient(
+      circle at 14% 18%,
+      rgba(19, 203, 178, 0.14),
+      transparent 34%
+    ),
+    radial-gradient(
+      circle at 88% 82%,
+      rgba(157, 124, 255, 0.16),
+      transparent 34%
+    ),
     #17131d;
   color: #fff;
 }
@@ -84,6 +92,10 @@
   line-height: 1.08;
 }
 
+.d1-about-studio-pillar-icon {
+  display: none;
+}
+
 .d1-about-studio-pillar p {
   margin: 14px 0 0;
   color: rgba(255, 255, 255, 0.66);
@@ -107,23 +119,73 @@
 }
 
 @media (max-width: 680px) {
+  .d1-about-studio {
+    padding-block: 42px;
+  }
+
+  .d1-about-studio-layout {
+    gap: 24px;
+  }
+
+  .d1-about-studio-media img {
+    aspect-ratio: 16 / 10;
+    border-radius: 20px;
+  }
+
+  .d1-about-studio-caption {
+    margin-top: 9px;
+    font-size: 11px;
+  }
+
+  .d1-about-studio h2 {
+    max-width: 340px;
+    font-size: clamp(31px, 9.5vw, 39px);
+    line-height: 0.98;
+  }
+
+  .d1-about-studio-intro {
+    display: none;
+  }
+
   .d1-about-studio-pillars {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+    margin-top: 24px;
+    border: 0;
   }
 
   .d1-about-studio-pillar,
   .d1-about-studio-pillar:nth-child(odd),
   .d1-about-studio-pillar:nth-child(even) {
-    padding: 26px 0;
-    border-right: 0;
+    min-height: 142px;
+    padding: 14px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.06);
   }
 
-  .d1-about-studio-media img {
-    aspect-ratio: 4 / 5;
-    border-radius: 26px;
+  .d1-about-studio-pillar-icon {
+    display: grid;
+    width: 38px;
+    height: 38px;
+    margin-bottom: 22px;
+    place-items: center;
+    border-radius: 12px;
+    background: rgba(19, 203, 178, 0.16);
+    color: #51e4d0;
   }
 
-  .d1-about-studio h2 {
-    font-size: clamp(40px, 12vw, 62px);
+  .d1-about-studio-pillar-icon svg {
+    width: 19px;
+    height: 19px;
+  }
+
+  .d1-about-studio-pillar h3 {
+    font-size: 16px;
+    line-height: 1.04;
+  }
+
+  .d1-about-studio-pillar p {
+    display: none;
   }
 }

--- a/src/components/AboutStudioPortal.jsx
+++ b/src/components/AboutStudioPortal.jsx
@@ -1,5 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
+import {
+  Clapperboard,
+  FlaskConical,
+  Layers3,
+  WandSparkles,
+} from 'lucide-react';
 import foundersPhoto from '../images/ceo/alexandra-andrey-anix.webp';
 import './AboutStudioPortal.css';
 
@@ -7,18 +13,22 @@ const pillars = [
   {
     title: 'Режиссура и драматургия',
     text: 'Основатели студии Андрей Царёв и Александра Севостьянова сами работают со сценариями и режиссурой. В команде — более 10 лет опыта в драматургии и создании историй.',
+    icon: Clapperboard,
   },
   {
     title: 'Наукоёмкий бэкграунд',
     text: 'В команде есть опыт работы с научными и технологическими темами. Поэтому мы умеем разбираться в сложной фактуре, а не только красиво её оформлять.',
+    icon: FlaskConical,
   },
   {
     title: 'AI + классический продакшн',
     text: 'Anix — полноценная анимационная студия. Мы профессионально используем AI как часть режиссёрского и производственного процесса — вместе с анимацией, дизайном, монтажом и другими инструментами.',
+    icon: WandSparkles,
   },
   {
     title: 'От ролика до визуальной системы',
     text: 'Можем сделать один ролик, а можем развить из него маскота, визуальный язык, серию материалов, презентационные и обучающие форматы.',
+    icon: Layers3,
   },
 ];
 
@@ -58,7 +68,11 @@ export default function AboutStudioPortal({ path }) {
   if (path !== '/' || !mountNode) return null;
 
   return createPortal(
-    <section className="d1-section d1-about-studio" id="about-studio" aria-labelledby="about-studio-title">
+    <section
+      className="d1-section d1-about-studio"
+      id="about-studio"
+      aria-labelledby="about-studio-title"
+    >
       <div className="d1-container d1-about-studio-layout">
         <div className="d1-about-studio-media">
           <img
@@ -67,27 +81,44 @@ export default function AboutStudioPortal({ path }) {
             loading="lazy"
             decoding="async"
           />
-          <p className="d1-about-studio-caption">Андрей Царёв и Александра Севостьянова — основатели Anix Studio</p>
+          <p className="d1-about-studio-caption">
+            Андрей Царёв и Александра Севостьянова — основатели Anix Studio
+          </p>
         </div>
 
         <div className="d1-about-studio-copy">
           <p className="d1-eyebrow">О студии</p>
-          <h2 id="about-studio-title">Собираем сложные темы в истории, которые хочется досмотреть</h2>
+          <h2 id="about-studio-title">
+            Собираем сложные темы в истории, которые хочется досмотреть
+          </h2>
           <p className="d1-about-studio-intro">
-            Anix Studio объединяет режиссуру, драматургию, анимацию и современные AI-инструменты. Мы работаем с продуктами и темами, где одного красивого кадра недостаточно: сначала нужно разобраться, что именно человек должен понять и почувствовать.
+            Anix Studio объединяет режиссуру, драматургию, анимацию и
+            современные AI-инструменты. Мы работаем с продуктами и темами, где
+            одного красивого кадра недостаточно: сначала нужно разобраться, что
+            именно человек должен понять и почувствовать.
           </p>
 
           <div className="d1-about-studio-pillars">
-            {pillars.map((pillar) => (
-              <article className="d1-about-studio-pillar" key={pillar.title}>
-                <h3>{pillar.title}</h3>
-                <p>{pillar.text}</p>
-              </article>
-            ))}
+            {pillars.map((pillar) => {
+              const Icon = pillar.icon;
+
+              return (
+                <article className="d1-about-studio-pillar" key={pillar.title}>
+                  <span
+                    className="d1-about-studio-pillar-icon"
+                    aria-hidden="true"
+                  >
+                    <Icon />
+                  </span>
+                  <h3>{pillar.title}</h3>
+                  <p>{pillar.text}</p>
+                </article>
+              );
+            })}
           </div>
         </div>
       </div>
     </section>,
-    mountNode,
+    mountNode
   );
 }

--- a/src/components/Design1TestPage.jsx
+++ b/src/components/Design1TestPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   ArrowRight,
   BadgeCheck,
@@ -17,6 +17,12 @@ import {
   Workflow,
 } from 'lucide-react';
 import SiteFooter from './SiteFooter';
+import {
+  getFallbackShowreelProvider,
+  resolveShowreelProvider,
+  SHOWREEL_EXTERNAL_URLS,
+  SHOWREEL_URLS,
+} from '../utils/showreelProvider';
 import logo from '../images/logoanix.png';
 import agrotechCaseImage from '../images/cases/agrotech.webp';
 import bondarchukCaseImage from '../images/cases/bondarchuk.webp';
@@ -35,8 +41,6 @@ import yurrobotCaseImage from '../images/cases/yurrobot.webp';
 import '../Design1TestPage.css';
 
 const telegramUrl = 'https://t.me/anix_helper';
-const showreelUrl =
-  'https://vkvideo.ru/video_ext.php?oid=-174933827&id=456239051&hash=8a2d51037c33a713&hd=3&autoplay=1';
 const videoFolderUrl =
   'https://drive.google.com/drive/folders/1XzaVX00V5xukMZwEF9Vb_WCbco2M7erA';
 
@@ -169,13 +173,13 @@ const compactCases = [
     name: 'АгроТех',
     text: 'История с героиней, где агротех выглядит как сфера будущего, а не сухая отрасль из отчета.',
     image: agrotechCaseImage,
-    href: '#cases',
+    href: '/cases/b2b/',
   },
   {
     name: 'Стартех',
     text: 'Переупаковка продукта под региональные B2B-компании и ролик, который говорит с рынком проще.',
     image: startechCaseImage,
-    href: '#cases',
+    href: '/cases/b2b/',
   },
   {
     name: 'Бондарчук',
@@ -193,7 +197,7 @@ const compactCases = [
     name: 'Factory Director',
     text: 'Конференционный ролик на базе маскота, который стал рабочей визитной карточкой бренда.',
     image: factoryDirectorCaseImage,
-    href: '#cases',
+    href: '/cases/b2b/',
   },
 ];
 
@@ -420,25 +424,66 @@ function DirectionCard({ item }) {
 
 function VideoShowreel({ variant = 'hero' }) {
   const [isOpen, setIsOpen] = useState(false);
+  const [provider, setProvider] = useState(null);
+  const [isResolving, setIsResolving] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    resolveShowreelProvider().then((resolvedProvider) => {
+      if (active) setProvider(resolvedProvider);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const handleOpen = async () => {
+    setIsResolving(true);
+    try {
+      const resolvedProvider = await resolveShowreelProvider({
+        forceRefresh: true,
+      });
+      setProvider(resolvedProvider);
+      setIsOpen(true);
+    } finally {
+      setIsResolving(false);
+    }
+  };
+
+  const activeProvider = provider || getFallbackShowreelProvider();
 
   return (
     <div className={`d1-showreel d1-showreel-${variant}`}>
       <div className="d1-showreel-frame">
         {isOpen ? (
-          <iframe
-            src={showreelUrl}
-            width="1280"
-            height="720"
-            title="Anix showreel"
-            allow="autoplay; encrypted-media; fullscreen; picture-in-picture; screen-wake-lock;"
-            frameBorder="0"
-            allowFullScreen
-          />
+          <>
+            <iframe
+              src={SHOWREEL_URLS[activeProvider]}
+              width="1280"
+              height="720"
+              title={`Anix showreel — ${activeProvider === 'vk' ? 'VK Video' : 'YouTube'}`}
+              allow="autoplay; encrypted-media; fullscreen; picture-in-picture; screen-wake-lock;"
+              frameBorder="0"
+              allowFullScreen
+              referrerPolicy="strict-origin-when-cross-origin"
+            />
+            {activeProvider === 'youtube' ? (
+              <a
+                className="d1-showreel-external"
+                href={SHOWREEL_EXTERNAL_URLS.youtube}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Открыть на YouTube
+              </a>
+            ) : null}
+          </>
         ) : (
           <button
             className="d1-showreel-poster"
             type="button"
-            onClick={() => setIsOpen(true)}
+            onClick={handleOpen}
+            disabled={isResolving}
           >
             <picture>
               <source
@@ -458,7 +503,9 @@ function VideoShowreel({ variant = 'hero' }) {
             <span className="d1-play">
               <PlayCircle aria-hidden="true" />
             </span>
-            <span className="d1-showreel-label">Смотреть showreel</span>
+            <span className="d1-showreel-label">
+              {isResolving ? 'Подбираем видеоплеер…' : 'Смотреть showreel'}
+            </span>
             <span className="d1-showreel-tag">
               AI-видео / фарма / HSE / маскоты / события
             </span>
@@ -472,7 +519,7 @@ function VideoShowreel({ variant = 'hero' }) {
 function Design1TestPage() {
   return (
     <main className="design1-test">
-<header className="d1-header">
+      <header className="d1-header">
         <nav
           className="d1-header-inner"
           aria-label="Навигация тестовой страницы Anix"
@@ -501,18 +548,25 @@ function Design1TestPage() {
 
       <section className="d1-hero d1-container" id="top">
         <div className="d1-hero-copy">
-          <p className="d1-eyebrow">
-            Anix Studio (Студия Аникс) — анимационная студия для сложных продуктов.
+          <p className="d1-eyebrow d1-hero-eyebrow">
+            Anix Studio (Студия Аникс) — анимационная студия для сложных
+            продуктов.
           </p>
           <h1 className="d1-hero-title">
             <span className="d1-hero-title-line">Делаем </span>
             <span className="d1-hero-title-line">сложное </span>
             <span className="d1-hero-title-line">интересным</span>
           </h1>
-                    <p className="d1-lead">
-            Сначала понимание. Потом восхищение. Anix помогает вовлекать в
-            сложные продукты, правила и идеи через 2D-анимацию, историю и ясную
-            драматургию.
+          <p className="d1-lead">
+            <span className="d1-desktop-copy">
+              Сначала понимание. Потом восхищение. Anix помогает вовлекать в
+              сложные продукты, правила и идеи через 2D-анимацию, историю и
+              ясную драматургию.
+            </span>
+            <span className="d1-mobile-copy">
+              Объясняем сложные продукты через историю, анимацию и сильный
+              визуал.
+            </span>
           </p>
           <p className="d1-microcopy">
             Разбираемся, кто будет смотреть ролик, ищем, где теряется внимание,
@@ -553,7 +607,12 @@ function Design1TestPage() {
           <div className="d1-proof-layout">
             <div>
               <p className="d1-eyebrow">Showreel + цифры</p>
-              <h2>Сначала понимание — потом восхищение</h2>
+              <h2>
+                <span className="d1-desktop-copy">
+                  Сначала понимание — потом восхищение
+                </span>
+                <span className="d1-mobile-copy">Цифры, не обещания</span>
+              </h2>
             </div>
             <p className="d1-section-lead">
               Хороший ролик не просит у зрителя лишнюю минуту на расшифровку. Он
@@ -573,11 +632,16 @@ function Design1TestPage() {
         <div className="d1-container">
           <div className="d1-section-head">
             <p className="d1-eyebrow">Что делаем</p>
-                        <h2>Перерабатываем сложное в интересное</h2>
+            <h2>
+              <span className="d1-desktop-copy">
+                Перерабатываем сложное в интересное
+              </span>
+              <span className="d1-mobile-copy">Что мы делаем</span>
+            </h2>
             <p className="d1-section-lead">
               Сначала ищем, где ломается внимание. Потом выбираем формат: ролик,
-              серия карточек, страница, визуальная система, презентационное видео
-              или экранный контент для события.
+              серия карточек, страница, визуальная система, презентационное
+              видео или экранный контент для события.
             </p>
           </div>
           <div className="d1-service-grid">
@@ -594,8 +658,11 @@ function Design1TestPage() {
             <div>
               <p className="d1-eyebrow">Наши кейсы</p>
               <h2>
-                Видео, которые уже работали в продажах, PR, фарме, HSE и на
-                событиях
+                <span className="d1-desktop-copy">
+                  Видео, которые уже работали в продажах, PR, фарме, HSE и на
+                  событиях
+                </span>
+                <span className="d1-mobile-copy">Кейсы, которые работают</span>
               </h2>
             </div>
           </div>
@@ -612,9 +679,7 @@ function Design1TestPage() {
           <div className="d1-section-head d1-section-head-row">
             <div>
               <p className="d1-eyebrow">Еще видео</p>
-              <h2>
-                Хотите еще кейсы?
-              </h2>
+              <h2>Еще видео</h2>
             </div>
             <a
               className="d1-button d1-button-primary"
@@ -639,7 +704,10 @@ function Design1TestPage() {
           <div className="d1-reasons-head">
             <p className="d1-eyebrow">Почему это работает</p>
             <h2>
-              Начинаем с главного — с результата
+              <span className="d1-desktop-copy">
+                Начинаем с главного — с результата
+              </span>
+              <span className="d1-mobile-copy">Цель → история → продакшн</span>
             </h2>
           </div>
           <div className="d1-reason-grid">
@@ -654,7 +722,10 @@ function Design1TestPage() {
         <div className="d1-container d1-process-layout">
           <div className="d1-process-copy">
             <p className="d1-eyebrow">Процесс</p>
-            <h2>Заранее фиксируем маршрут</h2>
+            <h2>
+              <span className="d1-desktop-copy">Заранее фиксируем маршрут</span>
+              <span className="d1-mobile-copy">Как работаем</span>
+            </h2>
             <p className="d1-section-lead">
               Особенно в фарме, HSE и корпоративных проектах. Там много
               согласующих, правил, экспертов и внезапных правок. Поэтому процесс
@@ -673,7 +744,12 @@ function Design1TestPage() {
         <div className="d1-container">
           <div className="d1-section-head">
             <p className="d1-eyebrow">Направления</p>
-            <h2>Anix уже шире, чем один формат роликов</h2>
+            <h2>
+              <span className="d1-desktop-copy">
+                Anix уже шире, чем один формат роликов
+              </span>
+              <span className="d1-mobile-copy">Выберите направление</span>
+            </h2>
           </div>
           <div className="d1-direction-grid">
             {directions.map((item) => (
@@ -707,11 +783,15 @@ function Design1TestPage() {
           <div>
             <p className="d1-eyebrow">Контакты</p>
             <h2>
-              Покажите нам продукт, правило или событие, которое сложно
-              объяснить
+              <span className="d1-desktop-copy">
+                Покажите нам продукт, правило или событие, которое сложно
+                объяснить
+              </span>
+              <span className="d1-mobile-copy">Есть сложная задача?</span>
             </h2>
             <p>
-              Мы предложим лучший формат для вашего запроса и скажем, с чего начать
+              Мы предложим лучший формат для вашего запроса и скажем, с чего
+              начать
             </p>
           </div>
           <div className="d1-final-actions">
@@ -745,6 +825,25 @@ function Design1TestPage() {
       </section>
 
       <SiteFooter />
+
+      <nav className="d1-mobile-dock" aria-label="Быстрая навигация">
+        <a href="#services">
+          <Workflow aria-hidden="true" />
+          <span>Услуги</span>
+        </a>
+        <a href="#cases">
+          <PlayCircle aria-hidden="true" />
+          <span>Кейсы</span>
+        </a>
+        <a href="#process">
+          <BadgeCheck aria-hidden="true" />
+          <span>Процесс</span>
+        </a>
+        <a href={heroLinks.telegram} target="_blank" rel="noreferrer">
+          <MessageCircle aria-hidden="true" />
+          <span>Написать</span>
+        </a>
+      </nav>
     </main>
   );
 }

--- a/src/components/Design1TestPage.jsx
+++ b/src/components/Design1TestPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import {
   ArrowRight,
   BadgeCheck,
@@ -17,12 +17,6 @@ import {
   Workflow,
 } from 'lucide-react';
 import SiteFooter from './SiteFooter';
-import {
-  getFallbackShowreelProvider,
-  resolveShowreelProvider,
-  SHOWREEL_EXTERNAL_URLS,
-  SHOWREEL_URLS,
-} from '../utils/showreelProvider';
 import logo from '../images/logoanix.png';
 import agrotechCaseImage from '../images/cases/agrotech.webp';
 import bondarchukCaseImage from '../images/cases/bondarchuk.webp';
@@ -41,6 +35,8 @@ import yurrobotCaseImage from '../images/cases/yurrobot.webp';
 import '../Design1TestPage.css';
 
 const telegramUrl = 'https://t.me/anix_helper';
+const showreelUrl =
+  'https://vkvideo.ru/video_ext.php?oid=-174933827&id=456239051&hash=8a2d51037c33a713&hd=3&autoplay=1';
 const videoFolderUrl =
   'https://drive.google.com/drive/folders/1XzaVX00V5xukMZwEF9Vb_WCbco2M7erA';
 
@@ -424,66 +420,25 @@ function DirectionCard({ item }) {
 
 function VideoShowreel({ variant = 'hero' }) {
   const [isOpen, setIsOpen] = useState(false);
-  const [provider, setProvider] = useState(null);
-  const [isResolving, setIsResolving] = useState(false);
-
-  useEffect(() => {
-    let active = true;
-    resolveShowreelProvider().then((resolvedProvider) => {
-      if (active) setProvider(resolvedProvider);
-    });
-    return () => {
-      active = false;
-    };
-  }, []);
-
-  const handleOpen = async () => {
-    setIsResolving(true);
-    try {
-      const resolvedProvider = await resolveShowreelProvider({
-        forceRefresh: true,
-      });
-      setProvider(resolvedProvider);
-      setIsOpen(true);
-    } finally {
-      setIsResolving(false);
-    }
-  };
-
-  const activeProvider = provider || getFallbackShowreelProvider();
 
   return (
     <div className={`d1-showreel d1-showreel-${variant}`}>
       <div className="d1-showreel-frame">
         {isOpen ? (
-          <>
-            <iframe
-              src={SHOWREEL_URLS[activeProvider]}
-              width="1280"
-              height="720"
-              title={`Anix showreel — ${activeProvider === 'vk' ? 'VK Video' : 'YouTube'}`}
-              allow="autoplay; encrypted-media; fullscreen; picture-in-picture; screen-wake-lock;"
-              frameBorder="0"
-              allowFullScreen
-              referrerPolicy="strict-origin-when-cross-origin"
-            />
-            {activeProvider === 'youtube' ? (
-              <a
-                className="d1-showreel-external"
-                href={SHOWREEL_EXTERNAL_URLS.youtube}
-                target="_blank"
-                rel="noreferrer"
-              >
-                Открыть на YouTube
-              </a>
-            ) : null}
-          </>
+          <iframe
+            src={showreelUrl}
+            width="1280"
+            height="720"
+            title="Anix showreel"
+            allow="autoplay; encrypted-media; fullscreen; picture-in-picture; screen-wake-lock;"
+            frameBorder="0"
+            allowFullScreen
+          />
         ) : (
           <button
             className="d1-showreel-poster"
             type="button"
-            onClick={handleOpen}
-            disabled={isResolving}
+            onClick={() => setIsOpen(true)}
           >
             <picture>
               <source
@@ -503,9 +458,7 @@ function VideoShowreel({ variant = 'hero' }) {
             <span className="d1-play">
               <PlayCircle aria-hidden="true" />
             </span>
-            <span className="d1-showreel-label">
-              {isResolving ? 'Подбираем видеоплеер…' : 'Смотреть showreel'}
-            </span>
+            <span className="d1-showreel-label">Смотреть showreel</span>
             <span className="d1-showreel-tag">
               AI-видео / фарма / HSE / маскоты / события
             </span>


### PR DESCRIPTION
## What changed
- redesign the homepage for a compact app-like mobile experience
- show all 8 additional video cards and replace placeholder jumps with working B2B destinations
- make the final recognition chip fully reachable
- compress the studio section into a four-icon mobile grid
- restore and adapt the full website lead form for phones
- preserve the existing desktop presentation

## Validation
- 18/18 tests passed
- ESLint passed
- production build passed locally and in the dev GitHub Actions workflow
- published preview checked for all 8 cards, application errors and page overflow
- all five direct Google Drive video links opened with the expected video titles
- internal B2B destinations opened successfully
