### PR TITLE
Pass database password to Supabase deploy

### DIFF
--- a/.github/workflows/supabase-functions.yml
+++ b/.github/workflows/supabase-functions.yml
@@ -23,10 +23,12 @@ jobs:
       - name: Link to Supabase project
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
         run: supabase link --project-ref ppoygmaqlaiqcisjetea
       - name: Apply database migrations
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
         run: supabase db push --include-all
       - name: Deploy all functions
         env:


### PR DESCRIPTION
## Причина

Production workflow не передавал пароль Postgres в Supabase CLI. `supabase db push` завершался с `SQLSTATE 28P01`, поэтому миграция и Edge Functions не выкладывались.

## Исправление

Передать GitHub Actions secret `SUPABASE_DB_PASSWORD` в шаги `supabase link` и `supabase db push` через поддерживаемую Supabase CLI переменную окружения.

## Проверка

- workflow YAML проверен;
- изменение ограничено двумя env bindings;
- после добавления repository secret и merge повторный push применит миграцию и задеплоит функции.