### PR TITLE
Make AI consultant page-aware and measurable

### DIFF
--- a/scripts/test-ai-grounding.mjs
+++ b/scripts/test-ai-grounding.mjs
@@ -4,27 +4,61 @@ import {
   buildGroundedReply,
   classifyGroundingIntent,
   groundingAliasMatches,
+  groundingPageContext,
+  groundingPageContextText,
+  groundingRetrievalQuery,
   groundingSearchSignature,
   inferGroundingVertical,
+  publicCaseCards,
   sanitizePublicReply,
+  shouldOfferProjectHandoff,
   sourcesFromCases,
+  suggestedFollowUps,
 } from '../supabase/functions/_shared/ai-grounding.mjs';
 
 const catalog = JSON.parse(
-  await fs.readFile(new URL('../data/ai-public-cases.json', import.meta.url), 'utf8')
+  await fs.readFile(
+    new URL('../data/ai-public-cases.json', import.meta.url),
+    'utf8'
+  )
 );
 const evaluation = JSON.parse(
-  await fs.readFile(new URL('../data/ai-rag-eval-cases.json', import.meta.url), 'utf8')
+  await fs.readFile(
+    new URL('../data/ai-rag-eval-cases.json', import.meta.url),
+    'utf8'
+  )
 );
 const morphologyMigration = await fs.readFile(
-  new URL('../supabase/migrations/011_ai_case_morphology_and_prompt_v6.sql', import.meta.url),
+  new URL(
+    '../supabase/migrations/011_ai_case_morphology_and_prompt_v6.sql',
+    import.meta.url
+  ),
+  'utf8'
+);
+const experienceMigration = await fs.readFile(
+  new URL(
+    '../supabase/migrations/012_ai_chat_context_feedback_and_handoff.sql',
+    import.meta.url
+  ),
   'utf8'
 );
 
-assert.match(morphologyMigration, /create or replace function public\.ai_search_signature/);
+assert.match(
+  morphologyMigration,
+  /create or replace function public\.ai_search_signature/
+);
 assert.match(morphologyMigration, /length\(token\) > 5 then left\(token, 5\)/);
-assert.match(morphologyMigration, /query\.signature @> public\.ai_search_signature/);
+assert.match(
+  morphologyMigration,
+  /query\.signature @> public\.ai_search_signature/
+);
 assert.match(morphologyMigration, /anix-consultant-v6/);
+assert.match(
+  experienceMigration,
+  /create table if not exists public\.ai_chat_feedback/
+);
+assert.match(experienceMigration, /feedback_rating/);
+assert.match(experienceMigration, /anix-consultant-v7/);
 
 const cases = catalog.cases.map((item) => ({
   display_name: item.displayName,
@@ -63,7 +97,10 @@ const resolveCatalogCase = (query) =>
     )
   );
 assert.equal(resolveCatalogCase('Подробнее про Мосфарму')?.slug, 'mosfarma');
-assert.equal(resolveCatalogCase('Что сделали для Гемотеха?')?.slug, 'hemotech-ai');
+assert.equal(
+  resolveCatalogCase('Что сделали для Гемотеха?')?.slug,
+  'hemotech-ai'
+);
 assert.equal(resolveCatalogCase('Расскажи про Aventis'), undefined);
 for (const [query, alias] of [
   ['Что сделали для Гемотеха?', 'Гемотех'],
@@ -71,10 +108,39 @@ for (const [query, alias] of [
   ['Расскажите о Мултоне', 'Мултон'],
   ['Какой результат у Бородина?', 'Бородино'],
 ]) {
-  assert.equal(groundingAliasMatches(query, alias), true, `Alias was not matched: ${query}`);
+  assert.equal(
+    groundingAliasMatches(query, alias),
+    true,
+    `Alias was not matched: ${query}`
+  );
 }
 assert.equal(groundingAliasMatches('Расскажи про Aventis', 'Мосфарма'), false);
-assert.deepEqual(groundingSearchSignature('Мосфарма и Мосфарму'), ['мосфа', 'и']);
+assert.deepEqual(groundingSearchSignature('Мосфарма и Мосфарму'), [
+  'мосфа',
+  'и',
+]);
+
+const casePageContext = groundingPageContext('/cases/mosfarma/');
+assert.equal(casePageContext.kind, 'case');
+assert.equal(casePageContext.vertical, 'medicine');
+assert.equal(casePageContext.caseName, 'Мосфарма');
+assert.match(groundingPageContextText(casePageContext), /прямо сейчас смотрит/);
+assert.match(
+  groundingRetrievalQuery(
+    'Какой результат?',
+    'Какой результат?',
+    casePageContext
+  ),
+  /Текущий кейс: Мосфарма/
+);
+assert.doesNotMatch(
+  groundingRetrievalQuery(
+    'Расскажи про Hemotech AI',
+    'Расскажи про Hemotech AI',
+    casePageContext
+  ),
+  /Текущий кейс: Мосфарма/
+);
 
 const pharmaIntent = classifyGroundingIntent({
   message: 'Расскажи про ваши кейсы с фармкомпаниями',
@@ -123,7 +189,9 @@ const missingFile = buildGroundedReply(
 assert.match(missingFile.reply, /нет файла/);
 assert.equal(missingFile.sources[0].url, 'https://t.me/anix_helper');
 
-const videoIntent = classifyGroundingIntent({ message: 'Отправь видео по Мосфарме' });
+const videoIntent = classifyGroundingIntent({
+  message: 'Отправь видео по Мосфарме',
+});
 assert.equal(videoIntent.mode, 'source');
 const videoReply = buildGroundedReply(videoIntent, [mosfarma]);
 assert(videoReply.sources.some((item) => item.kind === 'video'));
@@ -131,6 +199,35 @@ assert(videoReply.sources.some((item) => item.kind === 'video'));
 const publicSources = sourcesFromCases([mosfarma], { includeVideos: true });
 assert(publicSources.some((item) => item.kind === 'case_page'));
 assert(publicSources.every((item) => /^https:\/\//.test(item.url)));
+
+const cards = publicCaseCards([mosfarma]);
+assert.equal(cards.length, 1);
+assert.equal(cards[0].name, 'Мосфарма');
+assert.match(cards[0].result, /Первого канала/);
+assert(cards[0].links.some((item) => item.kind === 'case_page'));
+
+const followUps = suggestedFollowUps({
+  intent: { mode: 'case', vertical: 'medicine' },
+  cases: [mosfarma],
+  pageContext: casePageContext,
+  currentMessage: 'Расскажи подробнее',
+});
+assert.equal(followUps.length, 3);
+assert(followUps.some((item) => item.includes('результат')));
+assert.equal(
+  shouldOfferProjectHandoff({
+    message: 'Нам нужен ролик для врачей',
+    intent: { mode: 'general' },
+  }),
+  true
+);
+assert.equal(
+  shouldOfferProjectHandoff({
+    message: 'Расскажи про Мосфарму',
+    intent: { mode: 'case' },
+  }),
+  false
+);
 
 const sanitized = sanitizePublicReply(
   'Бюджет кейса — 900 000 ₽.\nКонтакт: client@example.com, +7 999 123-45-67, @private_client.\nПишите @anix_helper.'
@@ -152,7 +249,11 @@ for (const scenario of evaluation.cases) {
     `Wrong vertical for: ${scenario.input}`
   );
   if (scenario.providesContact) {
-    assert.equal(actual.providesContact, true, `Contact missed: ${scenario.input}`);
+    assert.equal(
+      actual.providesContact,
+      true,
+      `Contact missed: ${scenario.input}`
+    );
   }
   if (scenario.caseAlias) {
     assert.equal(
@@ -166,4 +267,6 @@ for (const scenario of evaluation.cases) {
   }
 }
 
-console.log(`AI grounding policy tests passed: ${evaluation.cases.length} scenarios`);
+console.log(
+  `AI grounding policy tests passed: ${evaluation.cases.length} scenarios`
+);

--- a/src/__tests__/aiArchitecture.test.js
+++ b/src/__tests__/aiArchitecture.test.js
@@ -16,6 +16,10 @@ describe('AI consultant production architecture', () => {
     expect(edge).toContain('storeAssistantFallback');
     expect(edge).toContain('buildGroundedReply');
     expect(edge).toContain('GROUNDING_POLICY_PROMPT');
+    expect(edge).toContain("action === 'feedback'");
+    expect(edge).toContain("action === 'handoff'");
+    expect(edge).toContain('groundingPageContextText(pageContext)');
+    expect(edge).toContain('publicCaseCards(structuredCases');
     expect(gateway).toContain("'/api/chat'");
     expect(gateway).toContain("'/api/embed'");
   });
@@ -30,5 +34,19 @@ describe('AI consultant production architecture', () => {
     ]) {
       expect(config).not.toContain(secret);
     }
+  });
+
+  test('keeps feedback and explicit CRM handoff server-owned', () => {
+    const migration = fs.readFileSync(
+      'supabase/migrations/012_ai_chat_context_feedback_and_handoff.sql',
+      'utf8'
+    );
+    const widget = fs.readFileSync('src/components/AiChatWidget.jsx', 'utf8');
+    expect(migration).toContain('public.ai_chat_feedback');
+    expect(migration).toContain('enable row level security');
+    expect(migration).toContain('anix-consultant-v7');
+    expect(widget).toContain("action: 'feedback'");
+    expect(widget).toContain("action: 'handoff'");
+    expect(widget).not.toContain('AMOCRM_LONG_LIVED_TOKEN');
   });
 });

--- a/src/__tests__/aiChatPageContext.test.js
+++ b/src/__tests__/aiChatPageContext.test.js
@@ -1,0 +1,39 @@
+import {
+  normalizeAiChatPath,
+  resolveAiChatPageContext,
+} from '../lib/aiChatPageContext';
+
+describe('AI chat page context', () => {
+  test('normalizes static route variants', () => {
+    expect(normalizeAiChatPath('/medicine/')).toBe('/medicine');
+    expect(normalizeAiChatPath('/cases/mosfarma/?utm_source=test')).toBe(
+      '/cases/mosfarma'
+    );
+    expect(normalizeAiChatPath('/')).toBe('/');
+  });
+
+  test('recognizes a concrete public case page', () => {
+    const context = resolveAiChatPageContext({
+      pathname: '/cases/mosfarma/',
+      title: 'Кейс Мосфарма',
+    });
+    expect(context.kind).toBe('case');
+    expect(context.vertical).toBe('medicine');
+    expect(context.caseSlug).toBe('mosfarma');
+    expect(context.caseName).toBe('Мосфарма');
+    expect(context.intro).toContain('Вы смотрите кейс «Мосфарма»');
+    expect(context.options).toContain('Какой результат у кейса «Мосфарма»?');
+  });
+
+  test('uses useful service-specific questions', () => {
+    const medicine = resolveAiChatPageContext({ pathname: '/medicine/' });
+    const hse = resolveAiChatPageContext({ pathname: '/hse/' });
+    const cases = resolveAiChatPageContext({ pathname: '/cases/' });
+    expect(medicine.vertical).toBe('medicine');
+    expect(medicine.options.join(' ')).toMatch(/фармкейсы|механизм действия/);
+    expect(hse.vertical).toBe('hse');
+    expect(hse.options.join(' ')).toMatch(/маскот|инструктаж/);
+    expect(cases.kind).toBe('catalog');
+    expect(cases.options.join(' ')).toMatch(/измеримым результатом/);
+  });
+});

--- a/src/__tests__/aiChatWidget.test.js
+++ b/src/__tests__/aiChatWidget.test.js
@@ -47,6 +47,7 @@ describe('AiChatWidget', () => {
             ok: true,
             session_id: '12345678-1234-4234-9234-123456789abc',
             session_token: 'session-secret',
+            message_id: '12345678-1234-4234-9234-123456789abe',
             reply: 'Покажем клинический workflow без перегруза.',
             fallback: false,
             crm_sync: 'not_requested',
@@ -58,6 +59,23 @@ describe('AiChatWidget', () => {
                 url: 'https://studio.anix-ai.pro/cases/hemotech-ai/',
               },
             ],
+            case_cards: [
+              {
+                id: 'case-hemotech',
+                slug: 'hemotech-ai',
+                name: 'Hemotech AI',
+                summary: 'Спокойно объяснили сложный медицинский AI-продукт.',
+                result: 'Ролик стал частью визуального языка бренда.',
+                links: [
+                  {
+                    kind: 'case_page',
+                    label: 'Открыть кейс',
+                    url: 'https://studio.anix-ai.pro/cases/hemotech-ai/',
+                  },
+                ],
+              },
+            ],
+            suggestions: ['Как сохранить научную точность?'],
           }),
       })
     );
@@ -92,7 +110,9 @@ describe('AiChatWidget', () => {
       );
       await Promise.resolve();
     });
-    expect(container.textContent).toContain('Что вы продвигаете');
+    expect(container.textContent).toContain(
+      'Вы изучаете направление Pharma и MedTech'
+    );
 
     const consent = container.querySelector(
       '.anix-ai-chat__verification input'
@@ -116,11 +136,14 @@ describe('AiChatWidget', () => {
     expect(payload.turnstile_token).toBe('turnstile-ai-token');
     expect(payload.privacy_consent).toBe(true);
     expect(payload.context.page_path).toBe('/medicine');
+    expect(payload.context.page_context.vertical).toBe('medicine');
+    expect(payload.context.page_context.kind).toBe('service');
     expect(container.textContent).toContain('Покажем клинический workflow');
     expect(container.textContent).toContain('Hemotech AI');
-    expect(container.querySelector('.anix-ai-chat__sources a').href).toBe(
+    expect(container.querySelector('.anix-ai-chat__case-links a').href).toBe(
       'https://studio.anix-ai.pro/cases/hemotech-ai/'
     );
+    expect(container.textContent).toContain('Как сохранить научную точность?');
     expect(
       JSON.parse(window.localStorage.getItem('anix_ai_chat_session_v1'))
     ).toEqual({
@@ -163,5 +186,119 @@ describe('AiChatWidget', () => {
     });
     expect(container.textContent).toContain('Сообщение сохранено');
     expect(container.textContent).toContain('Оставить контакт');
+  });
+
+  test('stores feedback for a concrete assistant message', async () => {
+    await TestUtils.act(async () => {
+      TestUtils.Simulate.click(
+        container.querySelector('.anix-ai-chat__launcher')
+      );
+      await Promise.resolve();
+    });
+    TestUtils.act(() => {
+      TestUtils.Simulate.change(
+        container.querySelector('.anix-ai-chat__verification input'),
+        { target: { checked: true } }
+      );
+      TestUtils.Simulate.change(container.querySelector('textarea'), {
+        target: { value: 'Покажите фармкейс.' },
+      });
+    });
+    await TestUtils.act(async () => {
+      TestUtils.Simulate.submit(
+        container.querySelector('.anix-ai-chat__composer')
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await TestUtils.act(async () => {
+      TestUtils.Simulate.click(
+        container.querySelector('button[aria-label="Ответ полезен"]')
+      );
+      await Promise.resolve();
+    });
+
+    const payload = JSON.parse(global.fetch.mock.calls[1][1].body);
+    expect(payload.action).toBe('feedback');
+    expect(payload.message_id).toBe('12345678-1234-4234-9234-123456789abe');
+    expect(payload.rating).toBe('positive');
+  });
+
+  test('lets a visitor review and hand off a structured brief', async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          ok: true,
+          session_id: '12345678-1234-4234-9234-123456789abc',
+          session_token: 'session-secret',
+          message_id: '12345678-1234-4234-9234-123456789abe',
+          reply: 'Для задачи подойдут объясняющий ролик и серия карточек.',
+          handoff: {
+            show: true,
+            title: 'Передать бриф команде',
+            summary: 'Нужно объяснить медицинскую технологию врачам.',
+            qualification: { industry: 'medicine', audience: 'врачи' },
+          },
+        }),
+    });
+    await TestUtils.act(async () => {
+      TestUtils.Simulate.click(
+        container.querySelector('.anix-ai-chat__launcher')
+      );
+      await Promise.resolve();
+    });
+    TestUtils.act(() => {
+      TestUtils.Simulate.change(
+        container.querySelector('.anix-ai-chat__verification input'),
+        { target: { checked: true } }
+      );
+      TestUtils.Simulate.change(container.querySelector('textarea'), {
+        target: { value: 'Нам нужен ролик для врачей.' },
+      });
+    });
+    await TestUtils.act(async () => {
+      TestUtils.Simulate.submit(
+        container.querySelector('.anix-ai-chat__composer')
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    TestUtils.act(() => {
+      TestUtils.Simulate.click(
+        container.querySelector('.anix-ai-chat__handoff-button')
+      );
+    });
+    const contactInput = container.querySelector('input[placeholder^="+7"]');
+    TestUtils.act(() => {
+      TestUtils.Simulate.change(contactInput, {
+        target: { value: '@project_owner' },
+      });
+    });
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          ok: true,
+          message_id: '12345678-1234-4234-9234-123456789abf',
+          reply: 'Бриф передан команде Anix.',
+          crm_sync: 'completed',
+        }),
+    });
+    await TestUtils.act(async () => {
+      TestUtils.Simulate.submit(
+        container.querySelector('.anix-ai-chat__brief')
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const payload = JSON.parse(global.fetch.mock.calls[1][1].body);
+    expect(payload.action).toBe('handoff');
+    expect(payload.contact).toBe('@project_owner');
+    expect(payload.task_summary).toContain('медицинскую технологию');
+    expect(container.textContent).toContain('Бриф передан команде Anix');
   });
 });

--- a/src/components/AiChatWidget.css
+++ b/src/components/AiChatWidget.css
@@ -293,6 +293,217 @@
   flex: 0 0 auto;
 }
 
+.anix-ai-chat__message--rich > div {
+  width: min(94%, 342px);
+  max-width: 94%;
+}
+
+.anix-ai-chat__case-cards {
+  display: grid;
+  gap: 9px;
+  margin-top: 11px;
+}
+
+.anix-ai-chat__case-cards article {
+  overflow: hidden;
+  border: 1px solid rgba(8, 125, 112, 0.22);
+  border-radius: 14px;
+  background: #f4fcfa;
+}
+
+.anix-ai-chat__case-cards article > img {
+  display: block;
+  width: 100%;
+  height: 92px;
+  object-fit: cover;
+  background: var(--chat-soft);
+}
+
+.anix-ai-chat__case-card-copy {
+  padding: 10px;
+}
+
+.anix-ai-chat__case-card-copy > span {
+  display: block;
+  margin-bottom: 3px;
+  color: rgba(7, 95, 86, 0.7);
+  font-size: 9px;
+  font-weight: 850;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.anix-ai-chat__case-card-copy > strong {
+  display: block;
+  color: #064f48;
+  font-size: 14px;
+  font-weight: 900;
+  line-height: 1.25;
+}
+
+.anix-ai-chat__case-card-copy p {
+  margin: 6px 0 0;
+  color: rgba(21, 17, 24, 0.78);
+  font-size: 11px;
+  line-height: 1.42;
+}
+
+.anix-ai-chat__case-card-copy .anix-ai-chat__case-result {
+  padding-top: 7px;
+  border-top: 1px solid rgba(8, 125, 112, 0.13);
+  color: #075f56;
+}
+
+.anix-ai-chat__case-card-copy details {
+  margin-top: 7px;
+  color: rgba(21, 17, 24, 0.72);
+  font-size: 11px;
+}
+
+.anix-ai-chat__case-card-copy summary {
+  color: #075f56;
+  cursor: pointer;
+  font-weight: 800;
+}
+
+.anix-ai-chat__case-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 9px;
+}
+
+.anix-ai-chat__case-links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 8px;
+  border-radius: 9px;
+  background: #fff;
+  color: #075f56;
+  font-size: 10px;
+  font-weight: 850;
+  line-height: 1.2;
+  text-decoration: none;
+}
+
+.anix-ai-chat__case-links svg {
+  width: 12px;
+  height: 12px;
+}
+
+.anix-ai-chat__follow-ups {
+  display: grid;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+.anix-ai-chat__follow-ups button {
+  width: 100%;
+  padding: 7px 9px;
+  border: 1px solid rgba(21, 17, 24, 0.11);
+  border-radius: 10px;
+  background: rgba(243, 238, 229, 0.58);
+  color: rgba(21, 17, 24, 0.76);
+  cursor: pointer;
+  font-size: 10px;
+  font-weight: 750;
+  line-height: 1.3;
+  text-align: left;
+}
+
+.anix-ai-chat__follow-ups button:hover {
+  border-color: rgba(8, 125, 112, 0.28);
+  background: rgba(19, 203, 178, 0.08);
+  color: #075f56;
+}
+
+.anix-ai-chat__handoff-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 10px;
+  padding: 8px 10px;
+  border: 0;
+  border-radius: 11px;
+  background: var(--chat-ink);
+  color: #fff;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 850;
+}
+
+.anix-ai-chat__handoff-button svg {
+  width: 14px;
+  height: 14px;
+}
+
+.anix-ai-chat__handoff-button:disabled,
+.anix-ai-chat__follow-ups button:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+.anix-ai-chat__feedback {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 9px;
+  color: rgba(21, 17, 24, 0.45);
+  font-size: 9px;
+  font-weight: 700;
+}
+
+.anix-ai-chat__feedback button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 25px;
+  height: 25px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: rgba(21, 17, 24, 0.42);
+  cursor: pointer;
+}
+
+.anix-ai-chat__feedback button:hover,
+.anix-ai-chat__feedback button.is-active {
+  border-color: rgba(8, 125, 112, 0.18);
+  background: rgba(19, 203, 178, 0.09);
+  color: var(--chat-mint-dark);
+}
+
+.anix-ai-chat__feedback svg {
+  width: 13px;
+  height: 13px;
+}
+
+.anix-ai-chat__feedback-reasons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 6px;
+}
+
+.anix-ai-chat__feedback-reasons button {
+  padding: 5px 7px;
+  border: 1px solid rgba(21, 17, 24, 0.1);
+  border-radius: 999px;
+  background: #fff;
+  color: rgba(21, 17, 24, 0.62);
+  cursor: pointer;
+  font-size: 9px;
+  font-weight: 700;
+}
+
+.anix-ai-chat__feedback-reasons button:hover,
+.anix-ai-chat__feedback-reasons button.is-active {
+  border-color: rgba(8, 125, 112, 0.25);
+  color: var(--chat-mint-dark);
+}
+
 .anix-ai-chat__quick-list {
   display: flex;
   flex-wrap: wrap;
@@ -350,6 +561,134 @@
 
 .anix-ai-chat__typing span:nth-child(3) {
   animation-delay: 280ms;
+}
+
+.anix-ai-chat__brief {
+  display: grid;
+  gap: 9px;
+  margin: 2px 0 16px 38px;
+  padding: 12px;
+  border: 1px solid rgba(8, 125, 112, 0.24);
+  border-radius: 16px;
+  background: #f4fcfa;
+  box-shadow: 0 12px 30px rgba(8, 125, 112, 0.08);
+}
+
+.anix-ai-chat__brief-heading {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.anix-ai-chat__brief-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  background: var(--chat-ink);
+  color: #fff;
+}
+
+.anix-ai-chat__brief-icon svg {
+  width: 15px;
+}
+
+.anix-ai-chat__brief-heading strong,
+.anix-ai-chat__brief-heading span {
+  display: block;
+}
+
+.anix-ai-chat__brief-heading strong {
+  font-size: 12px;
+  font-weight: 900;
+}
+
+.anix-ai-chat__brief-heading div > span {
+  margin-top: 2px;
+  color: rgba(21, 17, 24, 0.54);
+  font-size: 9px;
+  font-weight: 650;
+}
+
+.anix-ai-chat__brief-heading > button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: rgba(21, 17, 24, 0.06);
+  color: var(--chat-ink);
+  cursor: pointer;
+}
+
+.anix-ai-chat__brief-heading > button svg {
+  width: 14px;
+}
+
+.anix-ai-chat__brief > label {
+  display: grid;
+  gap: 4px;
+  color: rgba(21, 17, 24, 0.65);
+  font-size: 9px;
+  font-weight: 800;
+}
+
+.anix-ai-chat__brief input,
+.anix-ai-chat__brief textarea {
+  width: 100%;
+  padding: 8px 9px;
+  resize: vertical;
+  border: 1px solid rgba(21, 17, 24, 0.13);
+  border-radius: 10px;
+  outline: none;
+  background: #fff;
+  color: var(--chat-ink);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.anix-ai-chat__brief input:focus,
+.anix-ai-chat__brief textarea:focus {
+  border-color: rgba(8, 125, 112, 0.46);
+  box-shadow: 0 0 0 3px rgba(19, 203, 178, 0.08);
+}
+
+.anix-ai-chat__brief-error {
+  margin: 0;
+  color: #a32f2f;
+  font-size: 10px;
+  font-weight: 750;
+}
+
+.anix-ai-chat__brief-submit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  min-height: 36px;
+  padding: 8px 11px;
+  border: 0;
+  border-radius: 11px;
+  background: var(--chat-ink);
+  color: #fff;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 850;
+}
+
+.anix-ai-chat__brief-submit:disabled {
+  cursor: default;
+  opacity: 0.4;
+}
+
+.anix-ai-chat__brief-submit svg {
+  width: 15px;
 }
 
 @keyframes anix-chat-dot {

--- a/src/components/AiChatWidget.jsx
+++ b/src/components/AiChatWidget.jsx
@@ -1,16 +1,24 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   ArrowUp,
+  CheckCircle2,
+  ClipboardList,
   ExternalLink,
   LoaderCircle,
   MessageCircle,
   Sparkles,
+  ThumbsDown,
+  ThumbsUp,
   X,
 } from 'lucide-react';
 import { CONFIG } from '../config';
 import { getLeadSessionSnapshot } from '../lib/leadSession';
 import { loadTurnstile } from '../lib/turnstile';
 import { track } from '../lib/analytics';
+import {
+  currentAiChatPageContext,
+  normalizeAiChatPath,
+} from '../lib/aiChatPageContext';
 import { toPublicHref } from '../seo/SeoHead';
 import './AiChatWidget.css';
 
@@ -21,54 +29,11 @@ const START_MESSAGE = {
   local: true,
 };
 
-const pagePrompts = {
-  medicine: {
-    intro:
-      'Что вы продвигаете: препарат, медицинское устройство или технологию?',
-    options: [
-      'Препарат для врачей',
-      'MedTech или диагностика',
-      'Обучение медицинской команды',
-    ],
-  },
-  hse: {
-    intro:
-      'Что нужно решить: onboarding, критический риск, инструктаж или другую задачу по безопасности?',
-    options: [
-      'Onboarding сотрудников',
-      'Критический риск',
-      'Инструктаж или микрообучение',
-    ],
-  },
-  animation: {
-    intro: 'Что нужно объяснить с помощью анимации?',
-    options: [
-      'Сложный продукт',
-      'Процесс или технологию',
-      'Нужен рекламный ролик',
-    ],
-  },
-  cases: {
-    intro: 'Подберём подход к вашей задаче. Что вы хотите показать?',
-    options: ['B2B-продукт', 'Медицинскую тему', 'Охрану труда'],
-  },
-  default: {
-    intro: 'Что вы хотите объяснить?',
-    options: [
-      'Продукт или технологию',
-      'Медицинскую тему',
-      'Охрану труда',
-      'Нужен рекламный ролик',
-      'Пока не знаю — помогите разобраться',
-    ],
-  },
-};
-
 function normalizedPath() {
   if (typeof window === 'undefined') return '/';
   const base = process.env.PUBLIC_URL || '';
   const value = window.location.pathname.replace(base, '') || '/';
-  return value === '/' ? '/' : value.replace(/\/+$/, '');
+  return normalizeAiChatPath(value);
 }
 
 function widgetVisible() {
@@ -93,20 +58,6 @@ function widgetVisible() {
     path.startsWith('/cases/') ||
     path === '/ceo'
   );
-}
-
-function promptForPath() {
-  const path = normalizedPath();
-  if (path.startsWith('/medicine') || path.startsWith('/cases/medicine')) {
-    return pagePrompts.medicine;
-  }
-  if (path.startsWith('/hse') || path.startsWith('/cases/hse')) {
-    return pagePrompts.hse;
-  }
-  if (path === '/animation' || path === '/ai-video')
-    return pagePrompts.animation;
-  if (path.startsWith('/cases')) return pagePrompts.cases;
-  return pagePrompts.default;
 }
 
 function readStoredSession() {
@@ -178,10 +129,105 @@ async function chatRequest(body, timeoutMs = 70_000) {
   }
 }
 
-function Message({ item }) {
+const FEEDBACK_OPTIONS = [
+  ['not_specific', 'Мало конкретики'],
+  ['wrong_fact', 'Неверный факт'],
+  ['missing_source', 'Нет источника'],
+  ['did_not_understand', 'Не понял вопрос'],
+  ['other', 'Другое'],
+];
+
+function pageRequestContext(pageContext) {
+  return {
+    ...getLeadSessionSnapshot(),
+    page_context: {
+      kind: pageContext.kind,
+      vertical: pageContext.vertical,
+      case_slug: pageContext.caseSlug,
+      case_name: pageContext.caseName,
+      title: pageContext.title,
+      heading: pageContext.heading,
+    },
+  };
+}
+
+function CaseCards({ cards = [] }) {
+  if (!cards.length) return null;
+  return (
+    <div className="anix-ai-chat__case-cards" aria-label="Подходящие кейсы">
+      {cards.map((card) => (
+        <article key={card.id || card.slug || card.name}>
+          {card.image_url ? (
+            <img src={card.image_url} alt="" loading="lazy" />
+          ) : null}
+          <div className="anix-ai-chat__case-card-copy">
+            <span>{card.category || card.vertical || 'Кейс Anix'}</span>
+            <strong>{card.name}</strong>
+            {card.summary ? <p>{card.summary}</p> : null}
+            {card.result ? (
+              <p className="anix-ai-chat__case-result">
+                <b>Результат:</b> {card.result}
+              </p>
+            ) : null}
+            {card.task || card.solution ? (
+              <details>
+                <summary>Задача и решение</summary>
+                {card.task ? (
+                  <p>
+                    <b>Задача:</b> {card.task}
+                  </p>
+                ) : null}
+                {card.solution ? (
+                  <p>
+                    <b>Решение:</b> {card.solution}
+                  </p>
+                ) : null}
+              </details>
+            ) : null}
+            {card.links?.length ? (
+              <div className="anix-ai-chat__case-links">
+                {card.links.map((link) => (
+                  <a
+                    href={link.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    key={`${link.kind}-${link.url}`}
+                  >
+                    {link.label}
+                    <ExternalLink aria-hidden="true" />
+                  </a>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function Message({
+  item,
+  showActions = false,
+  disabled = false,
+  onSuggestion,
+  onFeedback,
+  onHandoff,
+}) {
+  const [feedbackReasonsOpen, setFeedbackReasonsOpen] = useState(false);
+  const cardUrls = new Set(
+    (item.case_cards || []).flatMap((card) =>
+      (card.links || []).map((link) => link.url)
+    )
+  );
+  const extraSources = (item.sources || []).filter(
+    (source) => !cardUrls.has(source.url)
+  );
+  const feedbackRating = item.feedback?.rating || '';
+
   return (
     <div
-      className={`anix-ai-chat__message anix-ai-chat__message--${item.role}`}
+      className={`anix-ai-chat__message anix-ai-chat__message--${item.role}${item.case_cards?.length ? ' anix-ai-chat__message--rich' : ''}`}
     >
       {item.role === 'assistant' ? (
         <span className="anix-ai-chat__avatar" aria-hidden="true">
@@ -190,19 +236,22 @@ function Message({ item }) {
       ) : null}
       <div>
         <div className="anix-ai-chat__message-copy">
-          {item.content.split('\n').map((line, index) => (
-            <React.Fragment key={`${index}-${line.slice(0, 12)}`}>
-              {index ? <br /> : null}
-              {line}
-            </React.Fragment>
-          ))}
+          {String(item.content || '')
+            .split('\n')
+            .map((line, index) => (
+              <React.Fragment key={`${index}-${line.slice(0, 12)}`}>
+                {index ? <br /> : null}
+                {line}
+              </React.Fragment>
+            ))}
         </div>
-        {item.sources?.length ? (
+        <CaseCards cards={item.case_cards} />
+        {extraSources.length ? (
           <div
             className="anix-ai-chat__sources"
             aria-label="Материалы к ответу"
           >
-            {item.sources.map((source) => (
+            {extraSources.map((source) => (
               <a
                 href={source.url}
                 target="_blank"
@@ -218,6 +267,75 @@ function Message({ item }) {
             ))}
           </div>
         ) : null}
+        {showActions && item.suggestions?.length ? (
+          <div className="anix-ai-chat__follow-ups" aria-label="Уточнить ответ">
+            {item.suggestions.map((suggestion) => (
+              <button
+                type="button"
+                key={suggestion}
+                onClick={() => onSuggestion(suggestion)}
+                disabled={disabled}
+              >
+                {suggestion}
+              </button>
+            ))}
+          </div>
+        ) : null}
+        {showActions && item.handoff?.show ? (
+          <button
+            type="button"
+            className="anix-ai-chat__handoff-button"
+            onClick={() => onHandoff(item.handoff)}
+            disabled={disabled}
+          >
+            <ClipboardList aria-hidden="true" />
+            {item.handoff.title || 'Передать бриф команде'}
+          </button>
+        ) : null}
+        {item.role === 'assistant' && item.id && !item.local ? (
+          <div className="anix-ai-chat__feedback">
+            <span>Полезный ответ?</span>
+            <button
+              type="button"
+              className={feedbackRating === 'positive' ? 'is-active' : ''}
+              aria-label="Ответ полезен"
+              onClick={() => {
+                setFeedbackReasonsOpen(false);
+                onFeedback(item.id, 'positive', '');
+              }}
+            >
+              <ThumbsUp aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              className={feedbackRating === 'negative' ? 'is-active' : ''}
+              aria-label="Ответ не помог"
+              onClick={() => {
+                setFeedbackReasonsOpen(true);
+                onFeedback(item.id, 'negative', '');
+              }}
+            >
+              <ThumbsDown aria-hidden="true" />
+            </button>
+          </div>
+        ) : null}
+        {feedbackReasonsOpen ? (
+          <div className="anix-ai-chat__feedback-reasons">
+            {FEEDBACK_OPTIONS.map(([value, label]) => (
+              <button
+                type="button"
+                key={value}
+                className={item.feedback?.reason === value ? 'is-active' : ''}
+                onClick={() => {
+                  onFeedback(item.id, 'negative', value);
+                  setFeedbackReasonsOpen(false);
+                }}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        ) : null}
         {item.fallback ? (
           <span className="anix-ai-chat__fallback-label">
             Сообщение сохранено
@@ -228,12 +346,92 @@ function Message({ item }) {
   );
 }
 
+function BriefForm({ form, status, error, onChange, onClose, onSubmit }) {
+  return (
+    <form
+      className="anix-ai-chat__brief"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSubmit();
+      }}
+    >
+      <div className="anix-ai-chat__brief-heading">
+        <span className="anix-ai-chat__brief-icon" aria-hidden="true">
+          <ClipboardList />
+        </span>
+        <div>
+          <strong>Передать бриф команде</strong>
+          <span>В amoCRM уйдут задача и контекст разговора.</span>
+        </div>
+        <button type="button" onClick={onClose} aria-label="Закрыть бриф">
+          <X aria-hidden="true" />
+        </button>
+      </div>
+      <label>
+        <span>Имя</span>
+        <input
+          value={form.name}
+          onChange={(event) => onChange('name', event.target.value)}
+          maxLength={200}
+          placeholder="Как к вам обращаться"
+        />
+      </label>
+      <label>
+        <span>Компания</span>
+        <input
+          value={form.company}
+          onChange={(event) => onChange('company', event.target.value)}
+          maxLength={300}
+          placeholder="Необязательно"
+        />
+      </label>
+      <label>
+        <span>Телефон, email или Telegram</span>
+        <input
+          value={form.contact}
+          onChange={(event) => onChange('contact', event.target.value)}
+          maxLength={500}
+          placeholder="+7…, name@company.ru или @username"
+          required
+        />
+      </label>
+      <label>
+        <span>Задача</span>
+        <textarea
+          value={form.task_summary}
+          onChange={(event) => onChange('task_summary', event.target.value)}
+          maxLength={1600}
+          rows={3}
+          placeholder="Что нужно сделать и для кого"
+        />
+      </label>
+      {error ? (
+        <p className="anix-ai-chat__brief-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+      <button
+        type="submit"
+        className="anix-ai-chat__brief-submit"
+        disabled={status === 'sending' || !form.contact.trim()}
+      >
+        {status === 'sending' ? (
+          <LoaderCircle className="anix-ai-chat__spinner" />
+        ) : (
+          <CheckCircle2 aria-hidden="true" />
+        )}
+        {status === 'sending' ? 'Передаём…' : 'Передать команде Anix'}
+      </button>
+    </form>
+  );
+}
+
 export default function AiChatWidget() {
   const visible = useMemo(widgetVisible, []);
-  const pagePrompt = useMemo(promptForPath, []);
+  const pageContext = useMemo(currentAiChatPageContext, []);
   const [open, setOpen] = useState(false);
   const [messages, setMessages] = useState([
-    { ...START_MESSAGE, content: pagePrompt.intro },
+    { ...START_MESSAGE, content: pageContext.intro },
   ]);
   const [draft, setDraft] = useState('');
   const [sending, setSending] = useState(false);
@@ -243,6 +441,16 @@ export default function AiChatWidget() {
   const [restoring, setRestoring] = useState(true);
   const [turnstileToken, setTurnstileToken] = useState('');
   const [turnstileError, setTurnstileError] = useState('');
+  const [briefOpen, setBriefOpen] = useState(false);
+  const [briefStatus, setBriefStatus] = useState('idle');
+  const [briefError, setBriefError] = useState('');
+  const [briefForm, setBriefForm] = useState({
+    name: '',
+    company: '',
+    contact: '',
+    task_summary: '',
+    qualification: {},
+  });
   const panelRef = useRef(null);
   const inputRef = useRef(null);
   const messagesRef = useRef(null);
@@ -261,6 +469,7 @@ export default function AiChatWidget() {
       action: 'resume',
       session_id: stored.id,
       session_token: stored.token,
+      context: pageRequestContext(pageContext),
     })
       .then((result) => {
         if (cancelled) return;
@@ -274,7 +483,7 @@ export default function AiChatWidget() {
     return () => {
       cancelled = true;
     };
-  }, [visible]);
+  }, [pageContext, visible]);
 
   useEffect(() => {
     if (!visible || !open || session || restoring) return undefined;
@@ -383,7 +592,7 @@ export default function AiChatWidget() {
         turnstile_token: session ? undefined : turnstileToken,
         privacy_consent: session ? undefined : privacyConsent,
         privacy_policy_version: '2026-08-07',
-        context: getLeadSessionSnapshot(),
+        context: pageRequestContext(pageContext),
       });
       let activeSession = session;
       if (!session && result.session_id && result.session_token) {
@@ -394,10 +603,16 @@ export default function AiChatWidget() {
       setMessages((current) => [
         ...current,
         {
+          id: result.message_id,
           role: 'assistant',
           content: result.reply,
           fallback: Boolean(result.fallback),
           sources: Array.isArray(result.sources) ? result.sources : [],
+          case_cards: Array.isArray(result.case_cards) ? result.case_cards : [],
+          suggestions: Array.isArray(result.suggestions)
+            ? result.suggestions
+            : [],
+          handoff: result.handoff || null,
         },
       ]);
       track(result.fallback ? 'ai_chat_fallback' : 'ai_chat_message', {
@@ -431,6 +646,108 @@ export default function AiChatWidget() {
     }
   };
 
+  const submitFeedback = async (messageId, rating, reason) => {
+    if (!session || !messageId) return;
+    setMessages((current) =>
+      current.map((item) =>
+        item.id === messageId ? { ...item, feedback: { rating, reason } } : item
+      )
+    );
+    try {
+      await chatRequest({
+        action: 'feedback',
+        session_id: session.id,
+        session_token: session.token,
+        message_id: messageId,
+        rating,
+        reason,
+        context: pageRequestContext(pageContext),
+      });
+      track('ai_chat_feedback', {
+        page_path: pageContext.path,
+        rating,
+        reason,
+      });
+    } catch {
+      setMessages((current) =>
+        current.map((item) =>
+          item.id === messageId ? { ...item, feedback: null } : item
+        )
+      );
+    }
+  };
+
+  const openBrief = (offer) => {
+    const qualification = offer?.qualification || {};
+    setBriefForm({
+      name: qualification.name || '',
+      company: qualification.company || '',
+      contact: '',
+      task_summary: offer?.summary || qualification.current_problem || '',
+      qualification,
+    });
+    setBriefError('');
+    setBriefStatus('idle');
+    setBriefOpen(true);
+    track('ai_chat_handoff_open', { page_path: pageContext.path });
+    window.setTimeout(() => {
+      messagesRef.current?.scrollTo?.({
+        top: messagesRef.current.scrollHeight,
+        behavior: 'smooth',
+      });
+    }, 30);
+  };
+
+  const submitBrief = async () => {
+    if (!session || briefStatus === 'sending') return;
+    setBriefStatus('sending');
+    setBriefError('');
+    try {
+      const result = await chatRequest({
+        action: 'handoff',
+        request_id: makeRequestId(),
+        session_id: session.id,
+        session_token: session.token,
+        name: briefForm.name,
+        company: briefForm.company,
+        contact: briefForm.contact,
+        task_summary: briefForm.task_summary,
+        qualification: briefForm.qualification,
+        context: pageRequestContext(pageContext),
+      });
+      setMessages((current) => [
+        ...current,
+        {
+          id: result.message_id,
+          role: 'assistant',
+          content: result.reply,
+          fallback: Boolean(result.fallback),
+        },
+      ]);
+      setBriefStatus('success');
+      setBriefOpen(false);
+      track('ai_chat_handoff_submit', {
+        page_path: pageContext.path,
+        crm_sync: result.crm_sync,
+      });
+      if (result.crm_sync === 'completed') {
+        track('ai_chat_lead', { page_path: pageContext.path });
+      }
+    } catch (requestError) {
+      setBriefStatus('error');
+      setBriefError(
+        requestError.code === 'invalid_contact'
+          ? 'Укажите телефон, email или Telegram.'
+          : 'Не удалось передать бриф. Попробуйте ещё раз.'
+      );
+    }
+  };
+
+  const latestAssistantIndex = messages.reduce(
+    (last, item, index) => (item.role === 'assistant' ? index : last),
+    -1
+  );
+
   return (
     <div className={`anix-ai-chat${open ? ' anix-ai-chat--open' : ''}`}>
       {open ? (
@@ -445,7 +762,7 @@ export default function AiChatWidget() {
             </span>
             <div>
               <strong>Спросить Anix</strong>
-              <span>Консультант по сложным задачам</span>
+              <span>Контекст: {pageContext.label}</span>
             </div>
             <button
               type="button"
@@ -464,12 +781,17 @@ export default function AiChatWidget() {
             {messages.map((item, index) => (
               <Message
                 item={item}
+                showActions={index === latestAssistantIndex}
+                disabled={sending}
+                onSuggestion={submit}
+                onFeedback={submitFeedback}
+                onHandoff={openBrief}
                 key={`${item.role}-${index}-${item.content.slice(0, 16)}`}
               />
             ))}
             {messages.length === 1 ? (
               <div className="anix-ai-chat__quick-list">
-                {pagePrompt.options.map((option) => (
+                {pageContext.options.map((option) => (
                   <button
                     type="button"
                     onClick={() => submit(option)}
@@ -479,6 +801,19 @@ export default function AiChatWidget() {
                   </button>
                 ))}
               </div>
+            ) : null}
+            {briefOpen ? (
+              <BriefForm
+                form={briefForm}
+                status={briefStatus}
+                error={briefError}
+                onChange={(field, value) => {
+                  setBriefForm((current) => ({ ...current, [field]: value }));
+                  setBriefError('');
+                }}
+                onClose={() => setBriefOpen(false)}
+                onSubmit={submitBrief}
+              />
             ) : null}
             {messages.some((item) => item.fallback) ? (
               <button

--- a/src/lib/aiChatPageContext.js
+++ b/src/lib/aiChatPageContext.js
@@ -1,0 +1,184 @@
+const CASE_PAGES = {
+  clappy: { name: 'Clappy', vertical: 'b2b' },
+  'hemotech-ai': { name: 'Hemotech AI', vertical: 'medicine' },
+  tpes: { name: 'ТПЭС', vertical: 'b2b' },
+  'mfti-endowment': { name: 'Эндаумент-фонд МФТИ', vertical: 'b2b' },
+  mosfarma: { name: 'Мосфарма', vertical: 'medicine' },
+  'multon-partners': { name: 'Мултон Партнерс', vertical: 'hse' },
+  aviandr: { name: 'Авиандр', vertical: 'medicine' },
+  'little-prince': { name: 'Маленький принц', vertical: 'cinema' },
+  borodino: { name: 'Бородино', vertical: 'cinema' },
+  rchk: { name: 'РЧК', vertical: 'events' },
+};
+
+const PAGE_PROFILES = {
+  medicine: {
+    kind: 'service',
+    vertical: 'medicine',
+    label: 'Medicine',
+    intro:
+      'Вы изучаете направление Pharma и MedTech. Могу подобрать похожие кейсы, формат или способ объяснить медицинскую тему.',
+    options: [
+      'Покажите сильные фармкейсы Anix',
+      'Как визуализировать механизм действия препарата?',
+      'Как сохранить научную точность?',
+      'Что сделать для врачебной конференции?',
+    ],
+  },
+  hse: {
+    kind: 'service',
+    vertical: 'hse',
+    label: 'HSE',
+    intro:
+      'Вы изучаете решения Anix для HSE. Могу подобрать формат для правил безопасности, онбординга или обучения сотрудников.',
+    options: [
+      'Покажите кейсы Anix по охране труда',
+      'Что лучше: ролики, карточки или маскот?',
+      'Как сделать инструктаж заметным?',
+      'Как собрать HSE-кампанию?',
+    ],
+  },
+  animation: {
+    kind: 'service',
+    vertical: 'b2b',
+    label: 'Анимация',
+    intro:
+      'Могу помочь выбрать визуальный формат для сложного продукта, технологии, продажи или обучения.',
+    options: [
+      'Как объяснить сложный B2B-продукт?',
+      'Что лучше: ролик или презентация?',
+      'Как выбрать между 2D и AI-видео?',
+      'Сколько стоит минута ролика?',
+    ],
+  },
+  cases: {
+    kind: 'catalog',
+    vertical: null,
+    label: 'Кейсы Anix',
+    intro:
+      'Здесь собраны публичные кейсы Anix. Могу найти похожий проект, разобрать результат или подобрать кейс под вашу задачу.',
+    options: [
+      'Покажите кейсы с измеримым результатом',
+      'Подберите кейс для сложного B2B-продукта',
+      'Какие есть проекты для фармы?',
+      'Какие есть проекты для HSE?',
+    ],
+  },
+  process: {
+    kind: 'process',
+    vertical: null,
+    label: 'Подход Anix',
+    intro:
+      'Могу объяснить, почему визуальные истории работают, как устроен процесс Anix и какой формат подойдёт вашей задаче.',
+    options: [
+      'Как Anix начинает работу над сложной темой?',
+      'Что нужно подготовить для старта?',
+      'Как выбрать подходящий формат?',
+      'Покажите кейсы с результатами',
+    ],
+  },
+  team: {
+    kind: 'team',
+    vertical: null,
+    label: 'Команда Anix',
+    intro:
+      'Могу рассказать о компетенциях команды, подходе к сложным темам и релевантных проектах Anix.',
+    options: [
+      'В чём экспертиза команды Anix?',
+      'Как вы работаете со сложной фактурой?',
+      'Какие проекты делали для B2B?',
+    ],
+  },
+  default: {
+    kind: 'home',
+    vertical: null,
+    label: 'Anix Studio',
+    intro:
+      'Опишите, что нужно объяснить. Я подберу формат, релевантные кейсы и полезный следующий шаг.',
+    options: [
+      'Подберите формат под мою задачу',
+      'Покажите кейсы с результатами',
+      'Как объяснить сложный продукт?',
+      'Как выбрать между 2D и AI-видео?',
+      'Сколько стоит минута ролика?',
+    ],
+  },
+};
+
+export function normalizeAiChatPath(value = '/') {
+  const clean = String(value || '/')
+    .split('?')[0]
+    .split('#')[0]
+    .replace(/\/+$/, '');
+  return clean || '/';
+}
+
+function profileForPath(path) {
+  if (path === '/medicine' || path.startsWith('/cases/medicine')) {
+    return PAGE_PROFILES.medicine;
+  }
+  if (path === '/hse' || path.startsWith('/cases/hse')) {
+    return PAGE_PROFILES.hse;
+  }
+  if (path === '/animation' || path === '/ai-video') {
+    return PAGE_PROFILES.animation;
+  }
+  if (path === '/why_it_works') return PAGE_PROFILES.process;
+  if (path === '/ceo') return PAGE_PROFILES.team;
+  if (path.startsWith('/cases')) return PAGE_PROFILES.cases;
+  return PAGE_PROFILES.default;
+}
+
+export function resolveAiChatPageContext({
+  pathname = '/',
+  title = '',
+  heading = '',
+} = {}) {
+  const path = normalizeAiChatPath(pathname);
+  const match = path.match(/^\/cases\/([^/]+)$/);
+  const caseSlug = match?.[1] || '';
+  const casePage = CASE_PAGES[caseSlug];
+
+  if (casePage) {
+    return {
+      path,
+      kind: 'case',
+      vertical: casePage.vertical,
+      caseSlug,
+      caseName: casePage.name,
+      label: `Кейс «${casePage.name}»`,
+      title: String(title || '').slice(0, 300),
+      heading: String(heading || '').slice(0, 300),
+      intro: `Вы смотрите кейс «${casePage.name}». Могу разобрать задачу, решение, результат или показать подтверждённые материалы.`,
+      options: [
+        `Какая была задача в кейсе «${casePage.name}»?`,
+        `Что Anix сделал в кейсе «${casePage.name}»?`,
+        `Какой результат у кейса «${casePage.name}»?`,
+        `Где посмотреть кейс «${casePage.name}» и видео?`,
+      ],
+    };
+  }
+
+  const profile = profileForPath(path);
+  return {
+    path,
+    ...profile,
+    caseSlug: '',
+    caseName: '',
+    title: String(title || '').slice(0, 300),
+    heading: String(heading || '').slice(0, 300),
+  };
+}
+
+export function currentAiChatPageContext() {
+  if (typeof window === 'undefined') {
+    return resolveAiChatPageContext();
+  }
+  return resolveAiChatPageContext({
+    pathname: window.location.pathname,
+    title: document.title,
+    heading: document.querySelector('h1')?.textContent || '',
+  });
+}
+
+export const AI_CHAT_CASE_PAGES = CASE_PAGES;

--- a/supabase/functions/_shared/ai-grounding.mjs
+++ b/supabase/functions/_shared/ai-grounding.mjs
@@ -14,6 +14,19 @@ const PRICE_WORDS = /(?:цен[а-я]*|стоимост|сколько.*стои
 const CONTACT_WORDS =
   /(?:контакт|телефон|почт|e-?mail|связаться|свяж|написать вам|напишите мне|кому написать|менеджер|номер.*(?:директор|клиент)|(?:директор|клиент).*номер)/i;
 
+const CASE_PAGE_CONTEXT = {
+  clappy: { name: 'Clappy', vertical: 'b2b' },
+  'hemotech-ai': { name: 'Hemotech AI', vertical: 'medicine' },
+  tpes: { name: 'ТПЭС', vertical: 'b2b' },
+  'mfti-endowment': { name: 'Эндаумент-фонд МФТИ', vertical: 'b2b' },
+  mosfarma: { name: 'Мосфарма', vertical: 'medicine' },
+  'multon-partners': { name: 'Мултон Партнерс', vertical: 'hse' },
+  aviandr: { name: 'Авиандр', vertical: 'medicine' },
+  'little-prince': { name: 'Маленький принц', vertical: 'cinema' },
+  borodino: { name: 'Бородино', vertical: 'cinema' },
+  rchk: { name: 'РЧК', vertical: 'events' },
+};
+
 export function normalizeGroundingText(value) {
   return String(value || '')
     .toLowerCase()
@@ -26,22 +39,150 @@ export function normalizeGroundingText(value) {
 const SEARCH_STEM_LENGTH = 5;
 
 export function groundingSearchSignature(value) {
-  return [...new Set(
-    normalizeGroundingText(value)
-      .split(' ')
-      .filter(Boolean)
-      .map((token) =>
-        token.length > SEARCH_STEM_LENGTH
-          ? token.slice(0, SEARCH_STEM_LENGTH)
-          : token
-      )
-  )];
+  return [
+    ...new Set(
+      normalizeGroundingText(value)
+        .split(' ')
+        .filter(Boolean)
+        .map((token) =>
+          token.length > SEARCH_STEM_LENGTH
+            ? token.slice(0, SEARCH_STEM_LENGTH)
+            : token
+        )
+    ),
+  ];
 }
 
 export function groundingAliasMatches(query, alias) {
   const queryTokens = new Set(groundingSearchSignature(query));
   const aliasTokens = groundingSearchSignature(alias);
-  return aliasTokens.length > 0 && aliasTokens.every((token) => queryTokens.has(token));
+  return (
+    aliasTokens.length > 0 &&
+    aliasTokens.every((token) => queryTokens.has(token))
+  );
+}
+
+export function groundingPageContext(pagePath = '/') {
+  const path =
+    String(pagePath || '/')
+      .split('?')[0]
+      .split('#')[0]
+      .replace(/\/+$/, '') || '/';
+  const caseSlug = path.match(/^\/cases\/([^/]+)$/)?.[1] || '';
+  const casePage = CASE_PAGE_CONTEXT[caseSlug];
+  if (casePage) {
+    return {
+      path,
+      kind: 'case',
+      vertical: casePage.vertical,
+      caseSlug,
+      caseName: casePage.name,
+      label: `Кейс «${casePage.name}»`,
+    };
+  }
+  if (path === '/medicine' || path.startsWith('/cases/medicine')) {
+    return {
+      path,
+      kind: 'service',
+      vertical: 'medicine',
+      caseSlug: '',
+      caseName: '',
+      label: 'Pharma и MedTech',
+    };
+  }
+  if (path === '/hse' || path.startsWith('/cases/hse')) {
+    return {
+      path,
+      kind: 'service',
+      vertical: 'hse',
+      caseSlug: '',
+      caseName: '',
+      label: 'HSE и охрана труда',
+    };
+  }
+  if (path === '/animation' || path === '/ai-video') {
+    return {
+      path,
+      kind: 'service',
+      vertical: 'b2b',
+      caseSlug: '',
+      caseName: '',
+      label: 'Визуальные форматы Anix',
+    };
+  }
+  if (path.startsWith('/cases')) {
+    return {
+      path,
+      kind: 'catalog',
+      vertical: null,
+      caseSlug: '',
+      caseName: '',
+      label: 'Каталог кейсов Anix',
+    };
+  }
+  if (path === '/why_it_works') {
+    return {
+      path,
+      kind: 'process',
+      vertical: null,
+      caseSlug: '',
+      caseName: '',
+      label: 'Подход и процесс Anix',
+    };
+  }
+  if (path === '/ceo') {
+    return {
+      path,
+      kind: 'team',
+      vertical: null,
+      caseSlug: '',
+      caseName: '',
+      label: 'Команда Anix',
+    };
+  }
+  return {
+    path,
+    kind: 'home',
+    vertical: null,
+    caseSlug: '',
+    caseName: '',
+    label: 'Anix Studio',
+  };
+}
+
+export function groundingPageContextText(pageContext = {}) {
+  const lines = [
+    `Текущая страница: ${pageContext.label || 'Anix Studio'} (${pageContext.path || '/'}).`,
+  ];
+  if (pageContext.vertical)
+    lines.push(`Направление страницы: ${pageContext.vertical}.`);
+  if (pageContext.caseName) {
+    lines.push(
+      `Посетитель прямо сейчас смотрит публичный кейс «${pageContext.caseName}».`
+    );
+    lines.push(
+      'Короткие вопросы без названия кейса относятся к этому кейсу, пока пользователь явно не сменил тему.'
+    );
+  }
+  lines.push(
+    'Используй страницу как контекст намерения, но факты подтверждай только VERIFIED CASES и KNOWLEDGE CONTEXT.'
+  );
+  return lines.join('\n');
+}
+
+export function groundingRetrievalQuery(
+  query = '',
+  currentMessage = '',
+  pageContext = {}
+) {
+  if (!pageContext?.caseName) return String(query || '');
+  const mentionsAnotherCase = Object.values(CASE_PAGE_CONTEXT).some(
+    (item) =>
+      item.name !== pageContext.caseName &&
+      groundingAliasMatches(currentMessage, item.name)
+  );
+  if (mentionsAnotherCase) return String(query || '');
+  return `${String(query || '').trim()}\nТекущий кейс: ${pageContext.caseName}`.trim();
 }
 
 export function inferGroundingVertical(messages = [], pagePath = '') {
@@ -55,22 +196,37 @@ export function inferGroundingVertical(messages = [], pagePath = '') {
   ) {
     return 'medicine';
   }
-  if (/(?:hse|охран.*труд|безопасност|инструктаж|жизненно важн.*правил|onboarding|онбординг|мултон|multon)/.test(combined)) {
+  if (
+    /(?:hse|охран.*труд|безопасност|инструктаж|жизненно важн.*правил|onboarding|онбординг|мултон|multon)/.test(
+      combined
+    )
+  ) {
     return 'hse';
   }
   if (/(?:событи|выступлен|шоу|конференц|рчк)/.test(combined)) return 'events';
   if (/(?:кино|cinema|историчес|бородин|маленьк.*принц)/.test(combined)) {
     return 'cinema';
   }
-  if (/(?:b2b|промышлен|технолог|продукт|продаж|тпэс|tpes|clappy|клаппи|мфти|физтех|эндаумент)/.test(combined)) return 'b2b';
+  if (
+    /(?:b2b|промышлен|технолог|продукт|продаж|тпэс|tpes|clappy|клаппи|мфти|физтех|эндаумент)/.test(
+      combined
+    )
+  )
+    return 'b2b';
   return null;
 }
 
-export function classifyGroundingIntent({ message, recentUserMessages = [], pagePath = '' }) {
+export function classifyGroundingIntent({
+  message,
+  recentUserMessages = [],
+  pagePath = '',
+}) {
   const cleanMessage = normalizeGroundingText(message);
   const providesContact =
     /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i.test(String(message || '')) ||
-    /(?:https?:\/\/t\.me\/|@)[A-Za-z][A-Za-z0-9_]{4,31}/i.test(String(message || '')) ||
+    /(?:https?:\/\/t\.me\/|@)[A-Za-z][A-Za-z0-9_]{4,31}/i.test(
+      String(message || '')
+    ) ||
     /(?:\+?\d[\d\s().-]{8,}\d)/.test(String(message || ''));
   const recent = recentUserMessages
     .map(normalizeGroundingText)
@@ -88,7 +244,8 @@ export function classifyGroundingIntent({ message, recentUserMessages = [], page
     return {
       mode: 'source',
       vertical,
-      broadCatalog: LIST_WORDS.test(cleanMessage) && !DETAIL_WORDS.test(cleanMessage),
+      broadCatalog:
+        LIST_WORDS.test(cleanMessage) && !DETAIL_WORDS.test(cleanMessage),
     };
   }
   if (FILE_WORDS.test(cleanMessage)) {
@@ -104,7 +261,8 @@ export function classifyGroundingIntent({ message, recentUserMessages = [], page
     return {
       mode: 'case',
       vertical,
-      broadCatalog: LIST_WORDS.test(cleanMessage) && !DETAIL_WORDS.test(cleanMessage),
+      broadCatalog:
+        LIST_WORDS.test(cleanMessage) && !DETAIL_WORDS.test(cleanMessage),
     };
   }
   return { mode: 'general', vertical, broadCatalog: false };
@@ -127,6 +285,128 @@ function safeHttpUrl(value) {
   } catch {
     return '';
   }
+}
+
+function cleanCardText(value, maxLength = 1600) {
+  return String(value || '')
+    .trim()
+    .slice(0, maxLength);
+}
+
+export function publicCaseCards(cases = [], limit = 3) {
+  const exactCases = cases.filter((item) => item?.exact_match === true);
+  const selected = (exactCases.length ? exactCases : cases).slice(
+    0,
+    exactCases.length ? 1 : Math.max(1, Math.min(Number(limit) || 3, 5))
+  );
+  return selected.map((item) => {
+    const assets = assetsOf(item);
+    const imageUrl = safeHttpUrl(
+      assets.find((asset) => asset?.kind === 'image')?.url
+    );
+    const links = assets
+      .filter((asset) => ['case_page', 'video'].includes(asset?.kind))
+      .map((asset) => ({
+        kind: cleanCardText(asset?.kind, 50),
+        label: cleanCardText(asset?.label, 120) || 'Открыть материал',
+        url: safeHttpUrl(asset?.url),
+      }))
+      .filter((asset) => asset.url);
+    const publicUrl = safeHttpUrl(item?.public_url);
+    if (publicUrl && !links.some((link) => link.url === publicUrl)) {
+      links.unshift({
+        kind: 'case_page',
+        label: 'Открыть кейс',
+        url: publicUrl,
+      });
+    }
+    return {
+      id: cleanCardText(item?.id, 64),
+      slug: cleanCardText(item?.slug, 100),
+      name: cleanCardText(item?.display_name || item?.title, 240),
+      vertical: cleanCardText(item?.vertical, 50),
+      category: cleanCardText(item?.category, 120),
+      summary: cleanCardText(item?.summary),
+      task: cleanCardText(item?.task),
+      solution: cleanCardText(item?.solution),
+      result: cleanCardText(item?.result),
+      image_url: imageUrl,
+      links: links.slice(0, 3),
+    };
+  });
+}
+
+export function suggestedFollowUps({
+  intent = {},
+  cases = [],
+  pageContext = {},
+  currentMessage = '',
+} = {}) {
+  const exactCase = cases.find((item) => item?.exact_match === true);
+  const current = normalizeGroundingText(currentMessage);
+  let candidates;
+
+  if (exactCase || pageContext.caseName) {
+    const name = exactCase?.display_name || pageContext.caseName;
+    const hasVideo = assetsOf(exactCase).some(
+      (asset) => asset?.kind === 'video'
+    );
+    candidates = [
+      `Какая была задача в кейсе «${name}»?`,
+      `Что именно Anix сделал в кейсе «${name}»?`,
+      `Какой получился результат у кейса «${name}»?`,
+      hasVideo
+        ? `Покажите видео кейса «${name}»`
+        : `Покажите похожие кейсы Anix`,
+    ];
+  } else if (intent.mode === 'price') {
+    candidates = [
+      'От чего зависит стоимость?',
+      'Помогите подобрать формат под задачу',
+      'Что нужно для точной оценки?',
+    ];
+  } else if ((intent.vertical || pageContext.vertical) === 'medicine') {
+    candidates = [
+      'Покажите похожие фармкейсы',
+      'Как сохранить научную точность?',
+      'Какой формат подойдёт врачам?',
+    ];
+  } else if ((intent.vertical || pageContext.vertical) === 'hse') {
+    candidates = [
+      'Покажите похожие HSE-кейсы',
+      'Что лучше: ролики, карточки или маскот?',
+      'Как превратить правила в кампанию?',
+    ];
+  } else if ((intent.vertical || pageContext.vertical) === 'events') {
+    candidates = [
+      'Покажите кейсы для мероприятий',
+      'Как собрать экранный контент в одну историю?',
+      'Что можно сделать для выступления руководителя?',
+    ];
+  } else {
+    candidates = [
+      'Подберите похожий кейс',
+      'Какой формат подойдёт моей задаче?',
+      'Что нужно подготовить для старта?',
+    ];
+  }
+
+  return [...new Set(candidates)]
+    .filter((value) => normalizeGroundingText(value) !== current)
+    .slice(0, 3);
+}
+
+export function shouldOfferProjectHandoff({
+  message = '',
+  intent = {},
+  commercialReadiness = '',
+} = {}) {
+  if (['qualified', 'ready'].includes(commercialReadiness)) return true;
+  if (intent?.providesContact || intent?.mode === 'price') return true;
+  const clean = normalizeGroundingText(message);
+  return /(?:нам нужен|нам нужна|нам нужно|мы хотим|хотим сделать|нужно сделать|хочу заказать|нужно запустить|есть срок|дедлайн|для нашей компании|для нашего продукта)/i.test(
+    clean
+  );
 }
 
 export function sourcesFromCases(cases = [], options = {}) {
@@ -159,7 +439,8 @@ export function sourcesFromCases(cases = [], options = {}) {
     }
   }
   return result.filter(
-    (item, index, all) => all.findIndex((candidate) => candidate.url === item.url) === index
+    (item, index, all) =>
+      all.findIndex((candidate) => candidate.url === item.url) === index
   );
 }
 
@@ -190,7 +471,12 @@ export function buildGroundedReply(intent, cases = []) {
       reply:
         'Ориентир по стоимости — от 300 тыс. до 1,5 млн ₽ за минуту готового ролика. Итог зависит от сложности сценария, визуального стиля, количества сцен и требований к производству. Для точной оценки оставьте заявку на сайте или напишите @anix_helper.',
       sources: [
-        { kind: 'contact', label: 'Написать Anix в Telegram', title: 'Anix', url: TELEGRAM_URL },
+        {
+          kind: 'contact',
+          label: 'Написать Anix в Telegram',
+          title: 'Anix',
+          url: TELEGRAM_URL,
+        },
       ],
       reason: 'approved_price_policy',
     };
@@ -200,7 +486,12 @@ export function buildGroundedReply(intent, cases = []) {
       reply:
         'Личными контактами клиентов и команды в чате не делимся. Связаться с Anix можно через форму заявки на сайте или в Telegram: @anix_helper.',
       sources: [
-        { kind: 'contact', label: 'Написать Anix в Telegram', title: 'Anix', url: TELEGRAM_URL },
+        {
+          kind: 'contact',
+          label: 'Написать Anix в Telegram',
+          title: 'Anix',
+          url: TELEGRAM_URL,
+        },
       ],
       reason: 'contact_policy',
     };
@@ -210,12 +501,13 @@ export function buildGroundedReply(intent, cases = []) {
   const selectedCases = exactCases.length ? exactCases : cases;
 
   if (intent?.mode === 'file') {
-    const documents = sourcesFromCases(selectedCases, { includeDocuments: true }).filter(
-      (item) => item.kind === 'document'
-    );
+    const documents = sourcesFromCases(selectedCases, {
+      includeDocuments: true,
+    }).filter((item) => item.kind === 'document');
     if (documents.length) {
       return {
-        reply: 'Нашёл подтверждённые файлы по запросу. Они прикреплены к ответу.',
+        reply:
+          'Нашёл подтверждённые файлы по запросу. Они прикреплены к ответу.',
         sources: documents,
         reason: 'verified_documents',
       };
@@ -224,7 +516,12 @@ export function buildGroundedReply(intent, cases = []) {
       reply:
         'В подтверждённых материалах нет файла, который можно безопасно отправить по этому запросу. Запросите его через форму заявки на сайте или напишите @anix_helper.',
       sources: [
-        { kind: 'contact', label: 'Запросить материал в Telegram', title: 'Anix', url: TELEGRAM_URL },
+        {
+          kind: 'contact',
+          label: 'Запросить материал в Telegram',
+          title: 'Anix',
+          url: TELEGRAM_URL,
+        },
       ],
       reason: 'missing_document',
     };
@@ -236,7 +533,12 @@ export function buildGroundedReply(intent, cases = []) {
         reply:
           'В подтверждённых материалах нет ссылки по этому запросу. Можно уточнить её через форму заявки на сайте или у @anix_helper.',
         sources: [
-          { kind: 'contact', label: 'Уточнить у Anix', title: 'Anix', url: TELEGRAM_URL },
+          {
+            kind: 'contact',
+            label: 'Уточнить у Anix',
+            title: 'Anix',
+            url: TELEGRAM_URL,
+          },
         ],
         reason: 'missing_source',
       };
@@ -257,7 +559,12 @@ export function buildGroundedReply(intent, cases = []) {
         reply:
           'В публичных материалах Anix нет подтверждённого кейса с таким названием. Не буду придумывать детали. Можно уточнить у команды через форму заявки или @anix_helper.',
         sources: [
-          { kind: 'contact', label: 'Уточнить у Anix', title: 'Anix', url: TELEGRAM_URL },
+          {
+            kind: 'contact',
+            label: 'Уточнить у Anix',
+            title: 'Anix',
+            url: TELEGRAM_URL,
+          },
         ],
         reason: 'unknown_case',
       };
@@ -268,9 +575,14 @@ export function buildGroundedReply(intent, cases = []) {
           ? caseDetailReply(exactCases[0])
           : caseListReply(selectedCases),
       sources: sourcesFromCases(
-        exactCases.length === 1 && !intent.broadCatalog ? exactCases : selectedCases
+        exactCases.length === 1 && !intent.broadCatalog
+          ? exactCases
+          : selectedCases
       ),
-      reason: exactCases.length === 1 && !intent.broadCatalog ? 'exact_case' : 'case_list',
+      reason:
+        exactCases.length === 1 && !intent.broadCatalog
+          ? 'exact_case'
+          : 'case_list',
     };
   }
 
@@ -278,7 +590,8 @@ export function buildGroundedReply(intent, cases = []) {
 }
 
 export function structuredCaseContext(cases = []) {
-  if (!cases.length) return 'Подтверждённых структурированных кейсов по запросу нет.';
+  if (!cases.length)
+    return 'Подтверждённых структурированных кейсов по запросу нет.';
   return cases
     .slice(0, 8)
     .map(
@@ -295,7 +608,10 @@ export function sanitizePublicReply(value) {
     .join('\n');
   return withoutCommercialLines
     .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '')
-    .replace(/https?:\/\/t\.me\/(?!anix_helper\b)[A-Za-z][A-Za-z0-9_]{4,31}/gi, '')
+    .replace(
+      /https?:\/\/t\.me\/(?!anix_helper\b)[A-Za-z][A-Za-z0-9_]{4,31}/gi,
+      ''
+    )
     .replace(/@(?!anix_helper\b)[A-Za-z][A-Za-z0-9_]{4,31}/g, '')
     .replace(/(?:\+?\d[\d\s().-]{8,}\d)/g, (candidate) =>
       candidate.replace(/\D/g, '').length >= 10 ? '' : candidate

--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -8,9 +8,15 @@ import {
   GROUNDING_POLICY_PROMPT,
   buildGroundedReply,
   classifyGroundingIntent,
+  groundingPageContext,
+  groundingPageContextText,
+  groundingRetrievalQuery,
+  publicCaseCards,
   sanitizePublicReply,
+  shouldOfferProjectHandoff,
   sourcesFromCases,
   structuredCaseContext,
+  suggestedFollowUps,
 } from '../_shared/ai-grounding.mjs';
 
 const DEFAULT_ORIGINS = [
@@ -22,6 +28,14 @@ const DEFAULT_ORIGINS = [
 const MAX_BODY_BYTES = 48_000;
 const MAX_MESSAGE_LENGTH = 4000;
 const MAX_HISTORY_MESSAGES = 16;
+const FEEDBACK_REASONS = new Set([
+  '',
+  'not_specific',
+  'wrong_fact',
+  'missing_source',
+  'did_not_understand',
+  'other',
+]);
 const FALLBACK_REPLY =
   'Сейчас AI-консультант временно недоступен. Опишите задачу и оставьте удобный контакт — команда Anix продолжит разговор.';
 
@@ -113,6 +127,15 @@ function requestId(value: unknown): string {
   )
     ? candidate
     : crypto.randomUUID();
+}
+
+function uuid(value: unknown): string {
+  const candidate = text(value, 64);
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    candidate
+  )
+    ? candidate
+    : '';
 }
 
 async function sha256(value: string): Promise<string> {
@@ -290,6 +313,15 @@ function contextFromInput(input: any): any {
   };
 }
 
+function pageHintsFromInput(input: any): any {
+  const raw = safeObject(input?.context);
+  const clientPageContext = safeObject(raw.page_context);
+  return {
+    title: text(raw.page_title || clientPageContext.title, 500),
+    heading: text(clientPageContext.heading, 500),
+  };
+}
+
 async function createSession(
   sb: any,
   input: any,
@@ -306,6 +338,8 @@ async function createSession(
 
   const token = randomToken();
   const context = contextFromInput(input);
+  const pageContext = groundingPageContext(context.page_path);
+  const pageHints = pageHintsFromInput(input);
   const { data, error } = await sb
     .from('ai_chat_sessions')
     .insert({
@@ -316,12 +350,49 @@ async function createSession(
         privacy_consent_at: new Date().toISOString(),
         privacy_policy_version:
           text(input?.privacy_policy_version, 64) || '2026-08-07',
+        page_context: { ...pageContext, ...pageHints },
       },
     })
     .select('*')
     .single();
   if (error || !data) throw new Error('session_create_failed');
   return { session: data, sessionToken: token };
+}
+
+async function refreshSessionContext(
+  sb: any,
+  session: any,
+  input: any
+): Promise<any> {
+  if (!input?.context || typeof input.context !== 'object') return session;
+  const incoming = contextFromInput(input);
+  const pagePath = incoming.page_path || session.page_path || '/';
+  const pageContext = groundingPageContext(pagePath);
+  const pageHints = pageHintsFromInput(input);
+  const update: Record<string, any> = {
+    updated_at: new Date().toISOString(),
+    page_path: pagePath,
+    page_url: incoming.page_url || session.page_url,
+    pages_viewed: incoming.pages_viewed.length
+      ? incoming.pages_viewed
+      : session.pages_viewed,
+    attribution: {
+      ...safeObject(session.attribution),
+      ...safeObject(incoming.attribution),
+    },
+    metadata: {
+      ...safeObject(session.metadata),
+      page_context: { ...pageContext, ...pageHints },
+    },
+  };
+  const { data, error } = await sb
+    .from('ai_chat_sessions')
+    .update(update)
+    .eq('id', session.id)
+    .select('*')
+    .single();
+  if (error || !data) throw new Error('session_context_update_failed');
+  return data;
 }
 
 async function loadSession(sb: any, input: any): Promise<any> {
@@ -362,9 +433,28 @@ async function loadMessages(
     .order('created_at', { ascending: false })
     .limit(limit);
   if (error) throw new Error('message_history_failed');
-  return [...(data || [])].reverse().map((item) => ({
+  const ordered = [...(data || [])].reverse();
+  const messageIds = ordered.map((item) => item?.id).filter(Boolean);
+  let feedbackByMessage = new Map<string, any>();
+  if (messageIds.length) {
+    const feedback = await sb
+      .from('ai_chat_feedback')
+      .select('message_id,rating,reason')
+      .eq('session_id', sessionId)
+      .in('message_id', messageIds);
+    if (!feedback.error) {
+      feedbackByMessage = new Map(
+        (feedback.data || []).map((item: any) => [item.message_id, item])
+      );
+    }
+  }
+  return ordered.map((item) => ({
     ...item,
     sources: safePublicSources(item?.metadata?.sources),
+    case_cards: safeCaseCards(item?.metadata?.case_cards),
+    suggestions: safeSuggestions(item?.metadata?.suggestions),
+    handoff: safeHandoffOffer(item?.metadata?.handoff),
+    feedback: feedbackByMessage.get(item.id) || null,
   }));
 }
 
@@ -506,6 +596,86 @@ function safePublicSources(value: unknown): any[] {
     );
 }
 
+function safeResponseUrl(value: unknown): string {
+  const candidate = text(value, 2000);
+  if (!candidate) return '';
+  try {
+    const url = new URL(candidate);
+    return ['http:', 'https:'].includes(url.protocol) ? url.toString() : '';
+  } catch {
+    return '';
+  }
+}
+
+function safeSuggestions(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return [
+    ...new Set(value.map((item) => text(item, 240)).filter(Boolean)),
+  ].slice(0, 3);
+}
+
+function safeCaseCards(value: unknown): any[] {
+  if (!Array.isArray(value)) return [];
+  return value.slice(0, 5).map((item) => ({
+    id: text(item?.id, 64),
+    slug: text(item?.slug, 100),
+    name: text(item?.name, 240),
+    vertical: text(item?.vertical, 50),
+    category: text(item?.category, 120),
+    summary: text(item?.summary, 1600),
+    task: text(item?.task, 1600),
+    solution: text(item?.solution, 1600),
+    result: text(item?.result, 1600),
+    image_url: safeResponseUrl(item?.image_url),
+    links: Array.isArray(item?.links)
+      ? item.links
+          .slice(0, 3)
+          .map((link: any) => ({
+            kind: text(link?.kind, 50),
+            label: text(link?.label, 120) || 'Открыть материал',
+            url: safeResponseUrl(link?.url),
+          }))
+          .filter((link: any) => link.url)
+      : [],
+  }));
+}
+
+function safeHandoffOffer(value: unknown): any {
+  const offer = safeObject(value);
+  if (offer.show !== true) return null;
+  const qualification = safeObject(offer.qualification);
+  return {
+    show: true,
+    title: text(offer.title, 160) || 'Передать бриф команде',
+    summary: text(offer.summary, 1600),
+    qualification: {
+      name: text(qualification.name, 200),
+      company: text(qualification.company, 300),
+      industry: text(qualification.industry, 300),
+      task_type: text(qualification.task_type, 300),
+      audience: text(qualification.audience, 500),
+      format: text(qualification.format, 500),
+      deadline: text(qualification.deadline, 300),
+      current_problem: text(qualification.current_problem, 1200),
+    },
+  };
+}
+
+function handoffOffer(
+  show: boolean,
+  session: any,
+  qualification: any,
+  summary: string
+): any {
+  if (!show) return null;
+  return safeHandoffOffer({
+    show: true,
+    title: 'Передать бриф команде',
+    summary: summary || session.summary || qualification.current_problem || '',
+    qualification,
+  });
+}
+
 function sourcesFromChunks(chunks: any[]): any[] {
   return safePublicSources(
     chunks.map((chunk) => ({
@@ -526,9 +696,7 @@ function combinedSources(cases: any[], chunks: any[] = []): any[] {
 
 function sanitizeReplyLinks(reply: string, sources: any[]): string {
   const allowed = new Set(
-    sources
-      .map((source) => normalizedSourceUrl(source?.url))
-      .filter(Boolean)
+    sources.map((source) => normalizedSourceUrl(source?.url)).filter(Boolean)
   );
   const isAllowed = (url: string) => allowed.has(normalizedSourceUrl(url));
   let rejectedUnsupportedUrl = false;
@@ -564,7 +732,8 @@ function sanitizeReplyLinks(reply: string, sources: any[]): string {
   return [
     'Вот материалы, которые подтверждены базой Anix:',
     ...confirmedSources.map(
-      (source) => `— ${text(source?.title || source?.label, 300)}: ${source.url}`
+      (source) =>
+        `— ${text(source?.title || source?.label, 300)}: ${source.url}`
     ),
   ].join('\n');
 }
@@ -817,6 +986,142 @@ async function syncChatLead(
   }
 }
 
+async function handleFeedback(
+  sb: any,
+  session: any,
+  input: any,
+  origin: string
+): Promise<Response> {
+  const messageId = uuid(input?.message_id);
+  const rating = text(input?.rating, 20);
+  const reason = text(input?.reason, 50);
+  if (!messageId || !['positive', 'negative'].includes(rating)) {
+    return json({ error: 'invalid_feedback' }, 400, origin);
+  }
+  if (!FEEDBACK_REASONS.has(reason)) {
+    return json({ error: 'invalid_feedback_reason' }, 400, origin);
+  }
+  const message = await sb
+    .from('ai_chat_messages')
+    .select('id')
+    .eq('id', messageId)
+    .eq('session_id', session.id)
+    .eq('role', 'assistant')
+    .maybeSingle();
+  if (message.error || !message.data) {
+    return json({ error: 'message_not_found' }, 404, origin);
+  }
+  const stored = await sb.from('ai_chat_feedback').upsert(
+    {
+      session_id: session.id,
+      message_id: messageId,
+      rating,
+      reason: reason || null,
+      page_path: session.page_path,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: 'session_id,message_id' }
+  );
+  if (stored.error)
+    return json({ error: 'feedback_store_failed' }, 500, origin);
+  return json({ ok: true, feedback: { rating, reason } }, 200, origin);
+}
+
+async function handleHandoff(
+  sb: any,
+  session: any,
+  input: any,
+  id: string,
+  origin: string
+): Promise<Response> {
+  const contactInput = text(input?.contact, 500);
+  const deterministicContact = extractContact(contactInput);
+  if (!deterministicContact.explicit) {
+    return json({ error: 'invalid_contact' }, 400, origin);
+  }
+
+  const submitted = safeObject(input?.qualification);
+  const taskSummary = text(input?.task_summary, 1600);
+  const qualification = mergeQualification(session.qualification, {
+    name: text(input?.name || submitted.name, 200),
+    company: text(input?.company || submitted.company, 300),
+    contact: contactInput,
+    industry: text(submitted.industry, 300),
+    task_type: text(submitted.task_type, 300),
+    audience: text(submitted.audience, 500),
+    format: text(submitted.format, 500),
+    deadline: text(submitted.deadline, 300),
+    current_problem: taskSummary || text(submitted.current_problem, 1200),
+    desired_next_step: 'Обсудить задачу с командой Anix',
+  });
+  const contact = {
+    ...safeObject(session.contact),
+    ...normalizedContact(qualification, deterministicContact),
+  };
+  const summary =
+    taskSummary || text(session.summary, 3000) || 'Бриф из AI-чата сайта';
+  const recommendedNextAction = 'Связаться по брифу из AI-чата сайта';
+  const update = {
+    updated_at: new Date().toISOString(),
+    last_message_at: new Date().toISOString(),
+    qualification,
+    contact,
+    summary,
+    recommended_next_action: recommendedNextAction,
+    commercial_readiness: 'ready',
+    status: 'qualified',
+  };
+  const sessionUpdate = await sb
+    .from('ai_chat_sessions')
+    .update(update)
+    .eq('id', session.id);
+  if (sessionUpdate.error) {
+    return json({ error: 'handoff_store_failed' }, 500, origin);
+  }
+
+  const history = await loadMessages(sb, session.id, 40).catch(() => []);
+  const crmSync = await syncChatLead(
+    sb,
+    { ...session, ...update },
+    history,
+    qualification,
+    contact,
+    recommendedNextAction
+  );
+  const reply =
+    crmSync === 'completed'
+      ? 'Бриф передан команде Anix вместе с контекстом разговора. Свяжемся по указанному контакту.'
+      : 'Бриф сохранён. Передача в CRM временно задержалась; повторно заполнять данные не нужно.';
+  const inserted = await sb
+    .from('ai_chat_messages')
+    .insert({
+      session_id: session.id,
+      request_id: id,
+      role: 'assistant',
+      content: reply,
+      delivery_status: crmSync === 'completed' ? 'completed' : 'fallback',
+      model: 'handoff-policy-v1',
+      metadata: { handoff_completed: crmSync === 'completed' },
+    })
+    .select('id')
+    .single();
+  await sb
+    .from('ai_chat_sessions')
+    .update({ message_count: Number(session.message_count || 0) + 1 })
+    .eq('id', session.id);
+  return json(
+    {
+      ok: true,
+      reply,
+      message_id: inserted.data?.id,
+      fallback: crmSync !== 'completed',
+      crm_sync: crmSync,
+    },
+    200,
+    origin
+  );
+}
+
 async function completeGroundedReply(
   sb: any,
   session: any,
@@ -827,31 +1132,50 @@ async function completeGroundedReply(
   history: any[],
   message: string,
   intent: any,
+  pageContext: any,
   cases: any[],
   grounded: any
 ): Promise<Response> {
   const sources = safePublicSources(grounded?.sources);
   const reply = text(grounded?.reply, 6000);
   const caseIds = cases.map((item) => item?.id).filter(Boolean);
-  const assistantInsert = await sb.from('ai_chat_messages').insert({
-    session_id: session.id,
-    request_id: id,
-    role: 'assistant',
-    content: reply,
-    delivery_status: 'completed',
-    retrieved_chunk_ids: [],
-    model: 'grounded-policy-v1',
-    total_latency_ms: Date.now() - started,
-    metadata: {
-      grounding: {
-        reason: text(grounded?.reason, 100),
-        mode: text(intent?.mode, 50),
-        vertical: text(intent?.vertical, 50),
-        case_ids: caseIds,
+  const caseCards = safeCaseCards(publicCaseCards(cases, 3));
+  const suggestions = safeSuggestions(
+    suggestedFollowUps({ intent, cases, pageContext, currentMessage: message })
+  );
+  const offer = handoffOffer(
+    shouldOfferProjectHandoff({ message, intent }),
+    session,
+    safeObject(session.qualification),
+    message
+  );
+  const assistantInsert = await sb
+    .from('ai_chat_messages')
+    .insert({
+      session_id: session.id,
+      request_id: id,
+      role: 'assistant',
+      content: reply,
+      delivery_status: 'completed',
+      retrieved_chunk_ids: [],
+      model: 'grounded-policy-v1',
+      total_latency_ms: Date.now() - started,
+      metadata: {
+        grounding: {
+          reason: text(grounded?.reason, 100),
+          mode: text(intent?.mode, 50),
+          vertical: text(intent?.vertical, 50),
+          case_ids: caseIds,
+        },
+        page_context: pageContext,
+        sources,
+        case_cards: caseCards,
+        suggestions,
+        handoff: offer,
       },
-      sources,
-    },
-  });
+    })
+    .select('id')
+    .single();
   if (assistantInsert.error) {
     return json({ error: 'message_store_failed' }, 500, origin);
   }
@@ -898,7 +1222,11 @@ async function completeGroundedReply(
     {
       ok: true,
       reply,
+      message_id: assistantInsert.data?.id,
       sources,
+      case_cards: caseCards,
+      suggestions,
+      handoff: offer,
       fallback: false,
       deterministic: true,
       session_id: session.id,
@@ -975,9 +1303,18 @@ async function handler(req: Request): Promise<Response> {
           : 401;
     return json({ error: code }, status, origin);
   }
-  const session = sessionResult.session;
+  let session = sessionResult.session;
+  try {
+    session = await refreshSessionContext(sb, session, input);
+  } catch (error) {
+    console.error(
+      `[ai-chat] Session context refresh failed: ${error instanceof Error ? error.message : 'unknown'}`
+    );
+  }
 
-  if (input?.action === 'resume') {
+  const action = text(input?.action, 32);
+
+  if (action === 'resume') {
     const messages = await loadMessages(sb, session.id).catch(() => []);
     return json(
       {
@@ -986,10 +1323,19 @@ async function handler(req: Request): Promise<Response> {
         messages,
         llm_status: session.llm_status,
         qualification: session.qualification,
+        page_context: groundingPageContext(session.page_path || '/'),
       },
       200,
       origin
     );
+  }
+
+  if (action === 'feedback') {
+    return handleFeedback(sb, session, input, origin);
+  }
+
+  if (action === 'handoff') {
+    return handleHandoff(sb, session, input, id, origin);
   }
 
   const message = text(input?.message, MAX_MESSAGE_LENGTH);
@@ -998,7 +1344,7 @@ async function handler(req: Request): Promise<Response> {
 
   const existing = await sb
     .from('ai_chat_messages')
-    .select('role,content,delivery_status,model,metadata')
+    .select('id,role,content,delivery_status,model,metadata')
     .eq('request_id', id)
     .eq('role', 'assistant')
     .maybeSingle();
@@ -1007,9 +1353,13 @@ async function handler(req: Request): Promise<Response> {
       {
         ok: true,
         duplicate: true,
+        message_id: existing.data.id,
         reply: existing.data.content,
         fallback: existing.data.delivery_status === 'fallback',
         sources: safePublicSources(existing.data.metadata?.sources),
+        case_cards: safeCaseCards(existing.data.metadata?.case_cards),
+        suggestions: safeSuggestions(existing.data.metadata?.suggestions),
+        handoff: safeHandoffOffer(existing.data.metadata?.handoff),
         session_id: session.id,
       },
       200,
@@ -1023,7 +1373,12 @@ async function handler(req: Request): Promise<Response> {
     role: 'user',
     content: message,
     delivery_status: 'stored',
-    metadata: { page_path: text(input?.context?.page_path, 1000) },
+    metadata: {
+      page_path: text(input?.context?.page_path, 1000),
+      page_context: groundingPageContext(
+        text(input?.context?.page_path, 1000) || session.page_path || '/'
+      ),
+    },
   });
   if (userInsert.error && userInsert.error.code !== '23505') {
     return json({ error: 'message_store_failed' }, 500, origin);
@@ -1032,6 +1387,9 @@ async function handler(req: Request): Promise<Response> {
   let history: any[];
   let intent: any;
   let structuredCases: any[];
+  const pageContext = groundingPageContext(
+    text(input?.context?.page_path, 1000) || session.page_path || '/'
+  );
   try {
     history = await loadMessages(sb, session.id, MAX_HISTORY_MESSAGES);
     const recentUserMessages = history
@@ -1040,11 +1398,15 @@ async function handler(req: Request): Promise<Response> {
     intent = classifyGroundingIntent({
       message,
       recentUserMessages,
-      pagePath: session.page_path || '',
+      pagePath: pageContext.path,
     });
+    if (!intent.vertical && pageContext.vertical) {
+      intent = { ...intent, vertical: pageContext.vertical };
+    }
+    const baseQuery = retrievalQuery(history, message);
     structuredCases = await retrieveStructuredCases(
       sb,
-      retrievalQuery(history, message),
+      groundingRetrievalQuery(baseQuery, message, pageContext),
       intent
     );
   } catch (error) {
@@ -1076,6 +1438,7 @@ async function handler(req: Request): Promise<Response> {
       history,
       message,
       intent,
+      pageContext,
       structuredCases,
       grounded
     );
@@ -1083,19 +1446,20 @@ async function handler(req: Request): Promise<Response> {
 
   let prompt: string;
   let retrieval: any;
+  const contextualRetrievalQuery = groundingRetrievalQuery(
+    retrievalQuery(history, message),
+    message,
+    pageContext
+  );
   try {
     [prompt, retrieval] = await Promise.all([
       activePrompt(sb),
-      retrieveKnowledge(
-        sb,
-        retrievalQuery(history, message),
-        session.page_path || '',
-        id
-      ),
+      retrieveKnowledge(sb, contextualRetrievalQuery, pageContext.path, id),
     ]);
     if (!prompt) throw new Error('system_prompt_missing');
   } catch (error) {
-    const errorClass = (error as GatewayFailure)?.errorClass || 'retrieval_error';
+    const errorClass =
+      (error as GatewayFailure)?.errorClass || 'retrieval_error';
     return storeAssistantFallback(
       sb,
       session,
@@ -1118,8 +1482,10 @@ async function handler(req: Request): Promise<Response> {
           role: item.role,
           content: item.content,
         })),
-        system_prompt: `${prompt}\n\n${GROUNDING_POLICY_PROMPT}`,
+        system_prompt: `${prompt}\n\n${GROUNDING_POLICY_PROMPT}\n\n${groundingPageContextText(pageContext)}`,
         retrieved_context: [
+          'PAGE CONTEXT',
+          groundingPageContextText(pageContext),
           'VERIFIED CASES',
           structuredCaseContext(structuredCases),
           'KNOWLEDGE CONTEXT',
@@ -1177,39 +1543,66 @@ async function handler(req: Request): Promise<Response> {
     ...normalizedContact(qualification, deterministicContact),
   };
   const chunkIds = retrieval.chunks.map((chunk: any) => chunk.id);
+  const caseCards = safeCaseCards(publicCaseCards(structuredCases, 3));
+  const suggestions = safeSuggestions(
+    suggestedFollowUps({
+      intent,
+      cases: structuredCases,
+      pageContext,
+      currentMessage: message,
+    })
+  );
+  const offer = handoffOffer(
+    shouldOfferProjectHandoff({
+      message,
+      intent,
+      commercialReadiness: envelope.commercial_readiness,
+    }),
+    session,
+    qualification,
+    envelope.summary
+  );
 
-  const assistantInsert = await sb.from('ai_chat_messages').insert({
-    session_id: session.id,
-    request_id: id,
-    role: 'assistant',
-    content: envelope.reply,
-    delivery_status: 'completed',
-    retrieved_chunk_ids: chunkIds,
-    model: text(gateway?.model, 200) || env('CHAT_MODEL') || 'qwen3:8b',
-    retrieval_latency_ms: retrieval.latencyMs,
-    llm_latency_ms: llmLatency,
-    total_latency_ms: Date.now() - started,
-    metadata: {
-      usage: safeObject(gateway?.usage),
-      retrieval: retrieval.chunks.map((chunk: any) => ({
-        id: chunk.id,
-        title: text(chunk.title, 300),
-        source_url: text(chunk.source_url, 2000),
-        vertical: text(chunk.metadata?.vertical, 50),
-        similarity: Number(chunk.similarity || 0),
-        lexical_rank: Number(chunk.lexical_rank || 0),
-        retrieval_score: Number(chunk.retrieval_score || 0),
-      })),
-      structured_cases: structuredCases.map((item: any) => ({
-        id: item.id,
-        slug: text(item.slug, 100),
-        display_name: text(item.display_name, 300),
-        exact_match: item.exact_match === true,
-        retrieval_score: Number(item.retrieval_score || 0),
-      })),
-      sources,
-    },
-  });
+  const assistantInsert = await sb
+    .from('ai_chat_messages')
+    .insert({
+      session_id: session.id,
+      request_id: id,
+      role: 'assistant',
+      content: envelope.reply,
+      delivery_status: 'completed',
+      retrieved_chunk_ids: chunkIds,
+      model: text(gateway?.model, 200) || env('CHAT_MODEL') || 'qwen3:8b',
+      retrieval_latency_ms: retrieval.latencyMs,
+      llm_latency_ms: llmLatency,
+      total_latency_ms: Date.now() - started,
+      metadata: {
+        usage: safeObject(gateway?.usage),
+        page_context: pageContext,
+        retrieval: retrieval.chunks.map((chunk: any) => ({
+          id: chunk.id,
+          title: text(chunk.title, 300),
+          source_url: text(chunk.source_url, 2000),
+          vertical: text(chunk.metadata?.vertical, 50),
+          similarity: Number(chunk.similarity || 0),
+          lexical_rank: Number(chunk.lexical_rank || 0),
+          retrieval_score: Number(chunk.retrieval_score || 0),
+        })),
+        structured_cases: structuredCases.map((item: any) => ({
+          id: item.id,
+          slug: text(item.slug, 100),
+          display_name: text(item.display_name, 300),
+          exact_match: item.exact_match === true,
+          retrieval_score: Number(item.retrieval_score || 0),
+        })),
+        sources,
+        case_cards: caseCards,
+        suggestions,
+        handoff: offer,
+      },
+    })
+    .select('id')
+    .single();
   if (assistantInsert.error)
     return json({ error: 'message_store_failed' }, 500, origin);
 
@@ -1272,6 +1665,7 @@ async function handler(req: Request): Promise<Response> {
     {
       ok: true,
       reply: envelope.reply,
+      message_id: assistantInsert.data?.id,
       fallback: false,
       session_id: session.id,
       session_token: sessionResult.sessionToken || undefined,
@@ -1279,6 +1673,9 @@ async function handler(req: Request): Promise<Response> {
       qualification,
       crm_sync: crmSync,
       sources,
+      case_cards: caseCards,
+      suggestions,
+      handoff: offer,
     },
     200,
     origin

--- a/supabase/migrations/012_ai_chat_context_feedback_and_handoff.sql
+++ b/supabase/migrations/012_ai_chat_context_feedback_and_handoff.sql
@@ -1,0 +1,113 @@
+create table if not exists public.ai_chat_feedback (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  session_id uuid not null references public.ai_chat_sessions(id) on delete cascade,
+  message_id uuid not null references public.ai_chat_messages(id) on delete cascade,
+  rating text not null check (rating in ('positive', 'negative')),
+  reason text check (
+    reason is null or reason in (
+      'not_specific',
+      'wrong_fact',
+      'missing_source',
+      'did_not_understand',
+      'other'
+    )
+  ),
+  page_path text,
+  metadata jsonb not null default '{}'::jsonb,
+  unique (session_id, message_id)
+);
+
+create index if not exists ai_chat_feedback_created_idx
+  on public.ai_chat_feedback (created_at desc);
+create index if not exists ai_chat_feedback_rating_idx
+  on public.ai_chat_feedback (rating, created_at desc);
+
+alter table public.ai_chat_feedback enable row level security;
+revoke all on table public.ai_chat_feedback from public, anon, authenticated;
+grant all on table public.ai_chat_feedback to service_role;
+
+create or replace view public.ai_chat_quality_diagnostics
+with (security_invoker = true)
+as
+select
+  message.id as message_id,
+  message.session_id,
+  message.created_at,
+  message.delivery_status,
+  message.model,
+  message.retrieval_latency_ms,
+  message.llm_latency_ms,
+  message.total_latency_ms,
+  message.error_class,
+  message.metadata -> 'grounding' ->> 'reason' as grounding_reason,
+  message.metadata -> 'grounding' ->> 'mode' as grounding_mode,
+  message.metadata -> 'grounding' ->> 'vertical' as grounding_vertical,
+  jsonb_array_length(coalesce(message.metadata -> 'sources', '[]'::jsonb)) as source_count,
+  jsonb_array_length(coalesce(message.metadata -> 'retrieval', '[]'::jsonb)) as retrieved_chunk_count,
+  jsonb_array_length(coalesce(message.metadata -> 'structured_cases', '[]'::jsonb)) as structured_case_count,
+  session.page_path,
+  session.crm_sync_status,
+  session.amocrm_lead_id,
+  feedback.rating as feedback_rating,
+  feedback.reason as feedback_reason,
+  message.metadata -> 'page_context' as page_context,
+  coalesce((message.metadata -> 'handoff' ->> 'show')::boolean, false) as handoff_offered
+from public.ai_chat_messages as message
+join public.ai_chat_sessions as session on session.id = message.session_id
+left join public.ai_chat_feedback as feedback on feedback.message_id = message.id
+where message.role = 'assistant';
+
+revoke all on table public.ai_chat_quality_diagnostics from public, anon, authenticated;
+grant select on table public.ai_chat_quality_diagnostics to service_role;
+
+create or replace view public.ai_chat_quality_daily
+with (security_invoker = true)
+as
+select
+  date_trunc('day', created_at) as day,
+  count(*) as assistant_messages,
+  count(*) filter (where delivery_status = 'fallback') as fallback_messages,
+  count(*) filter (where grounding_reason is not null) as deterministic_messages,
+  count(*) filter (where source_count > 0) as messages_with_sources,
+  round(avg(total_latency_ms)) as average_total_latency_ms,
+  count(*) filter (where crm_sync_status = 'completed') as crm_synced_messages,
+  count(*) filter (where feedback_rating = 'positive') as positive_feedback,
+  count(*) filter (where feedback_rating = 'negative') as negative_feedback,
+  count(*) filter (where handoff_offered) as handoff_offers
+from public.ai_chat_quality_diagnostics
+group by date_trunc('day', created_at);
+
+revoke all on table public.ai_chat_quality_daily from public, anon, authenticated;
+grant select on table public.ai_chat_quality_daily to service_role;
+
+update public.ai_chat_prompts set active = false where active = true;
+
+insert into public.ai_chat_prompts (name, version, content, active)
+select
+  'anix-consultant-v7',
+  7,
+  content || $experience$
+
+Контекстный режим сайта:
+- учитывай PAGE CONTEXT: пользователь может спрашивать «этот кейс», «а результат?» или «что сделали?» без повторения названия страницы;
+- не пересказывай страницу целиком и не упоминай её механически; используй её только когда это делает ответ точнее;
+- если человек описывает свою задачу, сначала коротко сформулируй, как ты её понял, затем предложи 2–3 различающихся формата;
+- к каждому предложенному формату поясни, для какой аудитории и канала он подходит;
+- релевантный кейс приводи как доказательство, а не как замену ответа;
+- за один ход задавай не больше одного уточняющего вопроса и не спрашивай то, что уже известно из PAGE CONTEXT или диалога;
+- не подталкивай к заявке в каждом сообщении; предлагай передачу брифа, когда появился проектный запрос, цена, срок или готовность обсуждать работу;
+- если найдено несколько близких кейсов, объясни одним предложением, почему каждый из них релевантен задаче посетителя.
+  $experience$,
+  true
+from public.ai_chat_prompts
+where name = 'anix-consultant-v6'
+on conflict (name) do update set
+  version = excluded.version,
+  content = excluded.content,
+  active = excluded.active,
+  updated_at = now();
+
+comment on table public.ai_chat_feedback is
+  'Server-owned visitor feedback for individual AI consultant answers.';


### PR DESCRIPTION
## Что меняется

- AI-консультант понимает текущую страницу и текущий кейс
- короткие вопросы на странице кейса привязываются к этому кейсу
- ответы могут возвращать проверенные карточки кейсов и релевантные следующие вопросы
- добавлены оценки ответа 👍/👎 с причинами и агрегаты качества
- добавлена явная форма брифа; только после подтверждения пользователя данные уходят через существующую amoCRM-интеграцию
- системный промт обновлён до v7, модель остаётся `qwen3:8b`

## Безопасность

- публичные кейсы и результаты берутся только из проверенного каталога
- неподтверждённые ссылки, файлы, контакты и цены не генерируются
- публичный ориентир цены остаётся 300 тыс. — 1,5 млн ₽ за минуту
- клиент не получает служебные ключи
- RLS для обратной связи: доступ только service role
- существующая логика amoCRM сохранена; без явной передачи контакта лид не создаётся

## Проверки

- `npm run lint`
- `npm run typecheck:edge`
- `npm run test:rag-quality` — 114 сценариев
- `npm run check:ai-scripts`
- `CI=true npm test -- --watchAll=false` — 28 тестов
- `npm run build`

## Ручная приёмка после деплоя

1. Открыть страницу кейса «Мосфарма»
2. Спросить: «Какой результат?»
3. Проверить, что ответ относится к Мосфарме и содержит только реальные ссылки
4. Оценить ответ и проверить запись feedback
5. Открыть форму брифа, но не отправлять тестовый лид без необходимости
